### PR TITLE
Adjust PublicKey.Verify API (take []bytes, only return error)

### DIFF
--- a/modules/modules.go
+++ b/modules/modules.go
@@ -18,7 +18,7 @@ type Multiaddr []byte
 
 type crypto.PublicKey interface {
   Encrypt([]byte) (crypto.Ciphertext, error)
-  Verify([]byte, crypto.Signature) (bool, error)
+  Verify([]byte, crypto.Signature) error
 }
 
 type crypto.PrivateKey interface {

--- a/modules/modules.go
+++ b/modules/modules.go
@@ -18,7 +18,7 @@ type Multiaddr []byte
 
 type crypto.PublicKey interface {
   Encrypt([]byte) (crypto.Ciphertext, error)
-  Verify(crypto.Signature) (bool, error)
+  Verify([]byte, crypto.Signature) (bool, error)
 }
 
 type crypto.PrivateKey interface {


### PR DESCRIPTION
Motivation for the two changes in their commit messages.