### PR TITLE
Separate filesystem merkle-path from IPLD merkle-path

### DIFF
--- a/merkledag/ipld.md
+++ b/merkledag/ipld.md
@@ -104,7 +104,8 @@ To unescape IPLD object keys that are not reserved and get the corresponding pat
 
 ### IPLD merkle-path (best solution)
 
-An _IPLD merkle-path_ is an extension of a _filesystem merkle-path_ which uses a special syntax to access link properties.
+An _IPLD merkle-path_ is an extension of a _filesystem merkle-path_ which uses a special syntax to access link properties. **[In case we use escaping in protobuf IPLD format** Except that key escaping is not performed when looking up items in the IPLD objects. This allow accessing reserved keys using _IPLD merkle-paths_ that are not accessible in filesystems.**]**
+
 
 Path elements are suffixed by either `.link` to access the link properties or by `.object` to dereference the _merkle-link_. if no suffix is present, the _merkle-link_ is dereferenced (to be compatible with _filesystem merkle-paths_ in most cases)
 

--- a/merkledag/ipld.md
+++ b/merkledag/ipld.md
@@ -35,6 +35,8 @@ There is no single merkle-path, but there are two:
 
 When you use a merkle path, make sure of which one you use. Command line tools are encouraged to allow switching between the two flavors using a switch.
 
+Filesystem representations (fuse mounts, HTTP or FTP protocols) should use the _filesystem merkle-paths_ if they intend to store arbitrary file. They can allow switching to _IPLD merkle-paths_ using a mount option or a configuration switch to allow object inspection, and turn the filesystem something like `/proc` or `/sys` on unix machines where storing user files is not the objective.
+
 ### Filesystem merkle-path
 
 A _filesystem merkle-path_ is a unix-style path which initially dereferences through a _merkle-link_ and then follows _named merkle-links_ in the intermediate objects. Following a name means looking into the object, finding the _name_ and resolving the associated _merkle-link_.

--- a/merkledag/ipld.md
+++ b/merkledag/ipld.md
@@ -85,6 +85,23 @@ O_5 = | "hello": "world"  |  whose hash value is QmR8Bzg59Y4FGWHeu9iTYhwhiP8PHCN
 
 This entire _merkle-path_ traversal is a unix-style path traversal over a _merkle-dag_ which uses _merkle-links_ with names.
 
+**[In case we use escaping in protobuf IPLD format]**
+
+In order to not restrict individual path component by disallowing some file names and still allow storing arbitrary data in IPLD objects, path components must be escaped when they are looked up in IPLD objects.
+
+To escape a path component in order to look it up in an IPLD object:
+
+- every `\` character in the path component must be replaced with `\\`
+- every `@` character in the path component must be replaced with `\@`
+
+This makes any key containing a `@` character unescaped in an IPLD object not accessible through a _filesystem merkle-path_. This is a reserved key that can be used to store auxiliary data without making it a link and visible in regular filesystems. This data can be made available in filesystems through extended attributes or opening and reading file contents.
+
+To unescape IPLD object keys that are not reserved and get the corresponding path component:
+
+- every `\@` sequence in the key must be replaced by `@`
+- every `\\` sequence in the key must be replaced by `\`
+
+
 ### IPLD merkle-path (best solution)
 
 An _IPLD merkle-path_ is an extension of a _filesystem merkle-path_ which uses a special syntax to access link properties.


### PR DESCRIPTION
This is an attempt at solving "**Accessing link properties problem (important issue to resolve)**" from PR #37

TODO items:

- [ ] Pending decision in PR #59 about path component escaping
- [ ] Decide which format to use for _IPLD merkle-paths_ (suffix, special character or other)
- [ ] Decide which suffix (`.object` vs `?object` vs `:object`) or which special character to use (`.` vs `|`)

I proposed two solutions, and one with a variant, corresponding to [these three ideas](/ipfs/specs/pull/37#issuecomment-158766176)

Introductions to the changes:

### What is a _merkle-path_?

A merkle-path is a unix-style path (e.g. `/a/b/c/d`) which initially dereferences through a _merkle-link_ and allows access of elements of the referenced node and other nodes transitively.

There is no single merkle-path, but there are two:

- merkle-path for filesystems: this is a merkle-path that is designed to be used in the context of filesystems (that also includes network protocols such as HTTP or FTP). Their idea is to be as close as possible to the traditional filesystem semantic
- merkle-path for IPLD: this is a merkle-path that can be used to access more elements of the IPLD data model (specifically: link properties) but that doesn't fit within the traditional filesystem model.

When you use a merkle path, make sure of which one you use. Command line tools are encouraged to allow switching between the two flavors using a switch.
