### PR TITLE
IPLD: precisions about canonical format

### DIFF
--- a/merkledag/ipld.md
+++ b/merkledag/ipld.md
@@ -308,6 +308,16 @@ In order to preserve merkle-linking's power, we must ensure that there is a sing
 
 **The IPLD Canonical format is _canonicalized CBOR_.**
 
+The legacy canonical format is protocol buffers.
+
+This canonical format is used to decide which format to use when creating the object for the first time and computing its hash. Once the format is decided for an IPLD object, it must be used in all communications so senders and receivers can check the data against the hash.
+
+For example, when sending a legacy object encoded in protocol buffers over the wire, the sender must not send the CBOR version as the receiver will not be able to check the file validity.
+
+In the same way, when the receiver is storing the object, it must make sure that the canonical format for this object is store along with the object so it will be able to share the object with other peers.
+
+A simple way to store such objects with their format is to store them with their multicodec header.
+
 
 ## Datastructure Examples
 


### PR DESCRIPTION
Child of PR #37 

Add precisions about the canonical format.

There was another solutions discussed: put a `@codec` key within the IPLD object when converting for instance a protocol buffer to JSON representation. There are problematic consequences:

- When receiving an object over the wire with the `@codec` key set to a format we know, we must decode and re-encode to this format to be sure that the hash is correct. Can be done.
- Makes it impossible to store JSON objects that have already a `@codec` key: we could document it as a limitation of the IPLD model
- We can't do anything with objects we receive that have a `@codec` key set to something we don't know.

It would be possible to escape the `@codec` key but:

- when getting the JSON representation of the IPLD object, the application must know that the key is escaped. We can no longer claim that applications authors can put arbitrary JSON on the system. They must know of this escaping scheme
- if the ipfs tools allows us to export a version of the JSON data with the `@codec` key containing the codec removed, and the `\@codec` escaped key in its unescaped form, it will be impossible to put the file back in the system because we loose the codec information.

It's best for application authors to deal with the multicodec header, or only deal with CBOR formatted objects and not with legacy protocol buffer objects.