### PR TITLE
WIP: IPFS API (core+http+cli)

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -1,14 +1,36 @@
-# IPFS API Spec
+IPFS API Specifications (core + http + cli)
+===========================================
 
-> Official spec of the APIs that ipfs implementations must conform to, as well as test suites to ensure they do.
+> This document presentes the specifications for the IPFS APIs, namely: 'core', the programmatic interface, 'http', a networked API interface over HTTP and 'cli', the command line interface to interact with IPFS.
 
-> **WARNING** This is a work in *progress*. There be dragons.
+Authors:
 
-The IPFS HTTP API Spec, in Apiary format, can be found in [ipfs/http-api-spec](//github.com/ipfs/http-api-spec).
+- David Dias
+- Richard Littauer
 
-The IPFS API has two levels. The first level is a general description based on function signatures and the second one is the transport specific description.
+Reviewers:
 
-* [Level 1 Spec - Transport Agnostic](level1.md)
-* Level 2 Spec - Transport Specific
-  * [Level 2 CLI Spec](level2/cli.md)
-  * [Level 2 HTTP(S) Spec](level2/http.md)
+- Jeromy Johnson
+- Juan Benet
+
+# Abstract
+
+This describes the [IPFS](https://ipfs.io/) APIs, including 'core', 'http' and 'cli'.
+
+# Status of this spec
+
+> **This spec is a Work In Progress (WIP).**
+
+# Organization of this document
+
+This RFC is organized by chapters described on the *Table of contents* section. Each of the chapters can be found in its own file.
+
+# Table of contents
+
+- [%N% Introduction]()
+- [%N% APIs]()
+  - [%N.M% Core]()
+  - [%N.M% HTTP]()
+  - [%N.M% CLI]()
+- [%N% Implementations]()
+- [%N% Referecences]()

--- a/api/README.md
+++ b/api/README.md
@@ -1,7 +1,7 @@
 IPFS API Specifications (core + http + cli)
 ===========================================
 
-> This document presentes the specifications for the IPFS APIs, namely: 'core', the programmatic interface, 'http', a networked API interface over HTTP and 'cli', the command line interface to interact with IPFS.
+> This document presents the specifications for the IPFS APIs, namely: 'core', the programmatic interface, 'http', a networked API interface over HTTP and 'cli', the command line interface to interact with IPFS.
 
 Authors:
 

--- a/api/cli/README.md
+++ b/api/cli/README.md
@@ -1,0 +1,97 @@
+# CLI Interface
+
+ipfs
+ipfs add
+ipfs bitswap
+ipfs bitswap stat
+ipfs bitswap unwant
+ipfs bitswap wantlist
+ipfs block
+ipfs block get
+ipfs block put
+ipfs block stat
+ipfs bootstrap
+ipfs bootstrap add
+ipfs bootstrap list
+ipfs bootstrap rm
+ipfs cat
+ipfs commands
+ipfs config
+ipfs config edit
+ipfs config replace
+ipfs config show
+ipfs daemon
+ipfs dht
+ipfs dht findpeer
+ipfs dht findprovs
+ipfs dht get
+ipfs dht put
+ipfs dht query
+ipfs diag
+ipfs diag net
+ipfs diag sys
+ipfs dns
+ipfs file
+ipfs file ls
+ipfs files
+ipfs files cp
+ipfs files ls
+ipfs files mkdir
+ipfs files mv
+ipfs files read
+ipfs files rm
+ipfs files stat
+ipfs files write
+ipfs get
+ipfs id
+ipfs init
+ipfs log
+ipfs log level
+ipfs log tail
+ipfs ls
+ipfs mount
+ipfs name
+ipfs name publish
+ipfs name resolve
+ipfs object
+ipfs object data
+ipfs object get
+ipfs object links
+ipfs object new
+ipfs object patch
+ipfs object patch add-link
+ipfs object patch append-data
+ipfs object patch rm-link
+ipfs object patch set-data
+ipfs object put
+ipfs object stat
+ipfs pin
+ipfs pin add
+ipfs pin ls
+ipfs pin rm
+ipfs ping
+ipfs refs
+ipfs refs local
+ipfs repo
+ipfs repo gc
+ipfs resolve
+ipfs stats
+ipfs stats bw
+ipfs swarm
+ipfs swarm addrs
+ipfs swarm addrs local
+ipfs swarm connect
+ipfs swarm disconnect
+ipfs swarm filters
+ipfs swarm filters add
+ipfs swarm filters rm
+ipfs swarm peers
+ipfs tar
+ipfs tar add
+ipfs tar cat
+ipfs tour
+ipfs tour list
+ipfs tour next
+ipfs tour restart
+ipfs update
+ipfs version

--- a/api/core/README.md
+++ b/api/core/README.md
@@ -39,7 +39,7 @@ The `core` API is the programmatic interface for IPFS, it defines the method sig
   - level
   - tail
 
-## Extentions
+## Extensions
 
 > Everything defined here is optional
 

--- a/api/core/README.md
+++ b/api/core/README.md
@@ -1,6 +1,8 @@
-# IPFS API Level 1 Spec - Transport Agnostic
+# Core API
 
-### IPFS Core
+The `core` API is the programmatic interface for IPFS, it defines the method signatures.
+
+## Required for compliant IPFS implementation
 
 > Everything defined here is required.
 
@@ -36,16 +38,16 @@
 - log
   - level
   - tail
-- name (ipns)
-  - name publish
-  - resolve
 
-### IPFS Ext
+## Extentions
 
 > Everything defined here is optional
 
+- name (ipns)
+  - name publish
+  - resolve
 - dns
-- resolve
+  - resolve
 - tar
   - add
   - cat
@@ -64,11 +66,15 @@
   - add
   - list
   - rm
+- bitswap
+  - stat
+  - unwant
+  - wantlist
 
-### IPFS Tools
 
-> Everything defined here is optional, and might be specific to the
-> implementation details (like running on the command line).
+## Tooling on top of the Core + Exntetions
+
+> Everything defined here is optional, and might be specific to the implementation details (like running on the command line).
 
 - commands
 - update
@@ -82,7 +88,7 @@
   - net
   - sys
 
-### Libp2p
+## Network API specifics that bubble up from libp2p API
 
 - ping
 - dht
@@ -100,10 +106,6 @@
   - filters add
   - filters rm
   - peers
-- record (iprs)
+- records (iprs)
   - put
   - get
-- bitswap
-  - stat
-  - unwant
-  - wantlist

--- a/api/core/README.md
+++ b/api/core/README.md
@@ -72,7 +72,7 @@ The `core` API is the programmatic interface for IPFS, it defines the method sig
   - wantlist
 
 
-## Tooling on top of the Core + Exntetions
+## Tooling on top of the Core + Extentions
 
 > Everything defined here is optional, and might be specific to the implementation details (like running on the command line).
 

--- a/api/http/README.md
+++ b/api/http/README.md
@@ -1,0 +1,12 @@
+> note: Currently, the HTTP API is a mix between a RPC and RESTful API
+
+# HTTP API
+
+
+
+# Interactive HTTP API documentation
+
+You can find a live version of the HTTP API on Apiary:
+
+- Apiary = http://docs.ipfs.apiary.io/#
+- Repo - https://github.com/ipfs/api

--- a/api/level2/cli.md
+++ b/api/level2/cli.md
@@ -1,1 +1,0 @@
-# IPFS API Level 2 CLI Spec

--- a/api/level2/http.md
+++ b/api/level2/http.md
@@ -1,1 +1,0 @@
-# IPFS API Level 2 HTTP(S) Spec


### PR DESCRIPTION
Upgraded the doc to reflect and indicate how we are organising our API specs. Moved from a `level` org to a `system` org (calling something level 1 and 2, when inside level 1 there are extensions and optional features made things a tad confusing).

Currently, the IPFS Core API (the programmatic interface) is still kind in flux (and that is ok), so no need to pressure ourselves into locking it down. The IPFS CLI happens as needed and as the system evolve. The only API spec that needs to get more stable, is the HTTP API as a lot of other libraries and applications depend on it.

Currently, the HTTP API is a mix of RPC and RESTful (it really isn't either), which makes it weird to assess. Having a RPC API gives us the chance of layering it over any other transport, while not having a RESTful one makes it weird for Web Apps libraries.

Let's continue the endeavour of documenting the current HTTP API through Apiary (here http://github.com/ipfs/api) so that then we can migrate through PR and reviews