### PR TITLE
Use absolute link to github

### DIFF
--- a/merkledag/README.md
+++ b/merkledag/README.md
@@ -1,11 +1,11 @@
 # The merkledag
 
 
-Authors: [Juan Benet](github.com/jbenet)
+Authors: [Juan Benet](https://github.com/jbenet)
 
 Reviewers:
 
-- [Jeromy Johnson](github.com/whyrusleeping)
+- [Jeromy Johnson](https://github.com/whyrusleeping)
 
 * * *
 
@@ -116,8 +116,8 @@ A powerful result of content (and identity) addressing is that linked data defin
 
 There exist many implementations of the merkledag format:
 
-- [go-merkledag](github.com/ipfs/go-merkledag)
-- [node-merkledag](github.com/ipfs/node-merkledag)
+- [go-merkledag](https://github.com/ipfs/go-merkledag)
+- [node-merkledag](https://github.com/ipfs/node-merkledag)
 
 ## Merkledag Notation
 


### PR DESCRIPTION
So they are actually clickable in https://github.com/ipfs/specs/tree/ipld-spec/merkledag