### PR TITLE
Added a "raw" tag for an edge node in the chunked file example.

### DIFF
--- a/ipld/README.md
+++ b/ipld/README.md
@@ -437,6 +437,7 @@ Split into multiple independent sub-Files.
     },
     {
       "@link": "QmAA1...",
+      "raw": true,
       "size": "120345"
     },
   ]


### PR DESCRIPTION
This is in part to resolve #2053 where jbenet said "by extending IPLD to allow just raw data edge nodes, we can make #875 easy to implement".