### PR TITLE
Remove dead link to IPNS

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The specs contained in this repository are:
 
 **Records and Record Systems:**
 - [IPRS](/iprs-interplanetary-record-system) - InterPlanetary Record System
-- [IPNS](ipns-interplanetary-naming-system) - InterPlanetary Naming System
+- IPNS - InterPlanetary Naming System
 
 **Key Management:**
 - [KeyStore](/keystore) - Key management on IPFS


### PR DESCRIPTION
I know this is here as a placeholder, but it is very confusing. See #113 and #120. If we want this to be a link, we should create an IPNS folder.