### PR TITLE
change r.Expires from time.Duration to time.Time

### DIFF
--- a/iprs-interplanetary-record-system/README.md
+++ b/iprs-interplanetary-record-system/README.md
@@ -41,7 +41,7 @@ For example, suppose Alice and Bob want to store records on a public bulletin bo
 ```go
 type Record struct {
   Value     []byte
-  Expires   time.Duration
+  Expires   time.Time
   Signature []byte
 }
 


### PR DESCRIPTION
All the code treats it as a `time.Time` and that's the only thing that makes sense here.

I know it's just an example but good, correct examples help understanding the ideas and reasoning behind a spec.
