### PR TITLE
Clarify where work is going on in the UnixFS spec

### DIFF
--- a/unixfs/README.md
+++ b/unixfs/README.md
@@ -1,32 +1,15 @@
 ![](https://img.shields.io/badge/status-wip-orange.svg?style=flat-square) unixfs
 ================================================================================
 
-Authors:
+Draft work and discussion on the upcoming UnixFS specification is happening in the [`ipfs/ipld-unixfs` repo](https://github.com/ipfs/unixfs-v2). Please see the issues there for discussion and PRs for drafts. When the specification is completed there, it will be copied back to this repo and replace this document.
 
-- n/a
-
-Reviewers:
-
-- n/a
-
-* * *
-
-# Abstract
-
-`TODO`
-
-# Organization of this document
-
-This spec is organized by chapters described on the *Table of contents* section. Each of the chapters can be found in its own file.
-
-# Table of contents
-
-- [1]()
-- [2]()
-- [...]()
+The current implementation of UnixFS has grown organically and does not currently have a clear specification. See [“implementations”](#implementations) below for reference implementations.
 
 # Implementations
 
 - JavaScript
   - Data Formats - [unixfs](https://github.com/ipfs/js-ipfs-unixfs)
   - Importers and Exporters - [unixfs-engine](https://github.com/ipfs/js-ipfs-unixfs-engine)
+- Go
+  - [`ipfs/go-ipfs/unixfs`](https://github.com/ipfs/go-ipfs/tree/b3faaad1310bcc32dc3dd24e1919e9edf51edba8/unixfs)
+  - Protocol Buffer Definitions - [`ipfs/go-ipfs/unixfs/pb`](https://github.com/ipfs/go-ipfs/blob/b3faaad1310bcc32dc3dd24e1919e9edf51edba8/unixfs/pb/unixfs.proto)

--- a/unixfs/README.md
+++ b/unixfs/README.md
@@ -1,9 +1,10 @@
 ![](https://img.shields.io/badge/status-wip-orange.svg?style=flat-square) unixfs
 ================================================================================
 
-Draft work and discussion on the upcoming UnixFS specification is happening in the [`ipfs/ipld-unixfs` repo](https://github.com/ipfs/unixfs-v2). Please see the issues there for discussion and PRs for drafts. When the specification is completed there, it will be copied back to this repo and replace this document.
+UnixFS is a [protocol-buffers](https://developers.google.com/protocol-buffers/) based format for describing files, directories, and symlinks in IPFS. The current implementation of UnixFS has grown organically and does not have a clear specification document. See [“implementations”](#implementations) below for reference implementations you can examine to understand the format.
 
-The current implementation of UnixFS has grown organically and does not currently have a clear specification. See [“implementations”](#implementations) below for reference implementations.
+Draft work and discussion on a specification for the upcoming version 2 of the UnixFS format is happening in the [`ipfs/unixfs-v2` repo](https://github.com/ipfs/unixfs-v2). Please see the issues there for discussion and PRs for drafts. When the specification is completed there, it will be copied back to this repo and replace this document.
+
 
 # Implementations
 


### PR DESCRIPTION
People get lost here when there’s no documentation and they don’t know about the `ipld-unixfs` repo, so I’ve replaced the empty specification with information about where current specification work is happening.

I’ve also updated the implementation section with links to the Go implementation. (@whyrusleeping are these the right links?)

(This is a follow-up to ipfs/unixfs-v2#8)