### PR TITLE
Fix broken links in Merkle DAG spec & explain deprecation

### DIFF
--- a/merkledag/README.md
+++ b/merkledag/README.md
@@ -1,6 +1,6 @@
 # The merkledag
 
-**This spec has been deprecated in favor of [IPLD](https://github.com/ipld/specs/tree/master/ipld)**
+**This spec has been deprecated in favor of [IPLD](https://github.com/ipld/specs/)**
 
 Authors: [Juan Benet](https://github.com/jbenet)
 
@@ -10,7 +10,7 @@ Reviewers:
 
 * * *
 
-This is the [Spec](../) for the IPFS Merkledag.
+This is the [Spec](https://github.com/ipfs/specs/) for the IPFS Merkledag.
 
 ## Definitions
 

--- a/merkledag/README.md
+++ b/merkledag/README.md
@@ -1,6 +1,6 @@
 # The merkledag
 
-**This spec has been deprecated in favor of [IPLD](https://github.com/ipld/specs/)**
+**This spec has been deprecated in favor of [IPLD](https://github.com/ipld/specs/).** It offers a clearer description of how to link different kinds of hash-based structures (e.g. linking a file in IPFS to a commit in Git), has a more generalized and flexible format, and uses a JSON-compatible representation, among other improvements.
 
 Authors: [Juan Benet](https://github.com/jbenet)
 


### PR DESCRIPTION
- Changed IPLD spec link just point to the IPLD specs repository rather than directly to the spec document, which has moved. We can either do this or point to a specific commit. Since I've been told the existing IPLD spec is not really stable/final, not pointing to a specific commit seemed better.

- Changed general specs link from relative to absolute. Relative links to branches (which is what you wind up with in this case) don't seem to work right on GitHub (they always get rendered as links to `<repo>/blob/<branch>` but it has to be `<repo>/tree/<branch>` to work, even though this is fine for files and subdirectories) :(

(Precipitated by #179)