### PR TITLE
fix IPLD broken link

### DIFF
--- a/merkledag/README.md
+++ b/merkledag/README.md
@@ -1,6 +1,6 @@
 # The merkledag
 
-**This spec has been deprecated in favor of [IPLD](https://github.com/ipld/specs/tree/master/ipld)**
+**This spec has been deprecated in favor of [IPLD](https://github.com/ipld/specs/tree/master)**
 
 Authors: [Juan Benet](https://github.com/jbenet)
 


### PR DESCRIPTION
The link for the IPLD github is returning 404: https://github.com/ipld/specs/tree/master/ipld
I believe the right link is https://github.com/ipld/specs/tree/master

Hope it helps!