### PR TITLE
fix cli public api link

### DIFF
--- a/public-api/README.md
+++ b/public-api/README.md
@@ -22,6 +22,6 @@ This RFC is organized by chapters described on the *Table of contents* section. 
 
 ## API
 
-- [CLI](./CLI)
+- [CLI](./cli)
 - [HTTP](./http)
 - [Core API (aka using IPFS as a package/module)](./core)


### PR DESCRIPTION
The link to CLI public api specs was broken as the directory name is lower-case.