### PR TITLE
RFC: Proposed protocol for insuring bitswap is more reliable

### DIFF
--- a/BITSWAP.md
+++ b/BITSWAP.md
@@ -87,8 +87,17 @@ message Message {
   Wantlist wantlist = 1;
   optional repeated bytes blocks = 2; 	// used to send Blocks in bitswap 1.0.0
   repeated Block payload = 3; // used to send Blocks in bitswap 1.1.0
+  bytes session_id = 3; // Bitswap 1.2 - id for this wantlist session
+  int32 frame_start = 4; // Bitswap 1.2 - start frame for deltas in a non-full message
+  int32 frame_end = 5; // Bitswap 1.2 - end frame for deltas in a non-full message
+  bytes ack_session_id = 6; // Bitswap 1.2 - acknowledge id for last received session_id
+  int32 ack_frame = 5; // Bitswap 1.2 - acknowledge last frame received
 }
 ```
+
+#### Error Correction
+
+Bitswap 1.2 introduces session ids and frames to make the protocol more reliable. When a new peer connects, the connection is assigned a local unique session id (likely a 16 byte uuid) and a starting frame (should be >0 which is the default value for protobuf ints). Each sent want list change or block send increments the frame counter. When sending a message, one or more frames are joined together, and sent with the local session id, and the starting and ending frame. When the remote peer sends its next message (or immediately), it sends last received local session id, and the last received and transmitted frame (along with its own session_id and frame range). Deltas are never applied unless the starting frame is lesser or equal to the last frame received and applied. Skillful buffering on both sides can use this mechanism to insure an accurate wantlist is maintained and blocks are resent when neccesary. Meanwhile, the fact that the rest of the protocol is identical means the presence of default (missing) values is used to detect and downgrade when communicating with older peers.
 
 ## Want-Manager
 


### PR DESCRIPTION
# Goals

We have been dealing with ongoing issues in `go-bitswap` with remote peers not sending wanted blocks because for any number of reasons, the want list on the remote peer becomes out of sync with the local peer. In addition the remote peer may send the block and think it's no longer wanted, but for whatever reason it's not received. We're currently dealing with all this by periodically re-sending the whole wantlist, but this is an imperfect fix. Fundamentally, the issue is that apart from sending the full wantlist, the bitswap protocol lacks any form of error correction that insures that all messages are received and processed in order.

# Implementation

The proposed change adds session ids and frame numbers to the protocol, to make it more reliable. It does so in a way that is backwards compatible when communicating with older peers.

When a new peer connects, the connection is assigned a local unique session id (likely a 16 byte uuid) and a starting frame (should be >0 which is the default value for protobuf ints). Each wantlist change or block send increments the frame counter. This includes a full wantlist send. Frames can be joined together using the following rules:
- wantlist delta frames are joined by simply applying the deltas successively
- wantlist full frames are joined by overwriting all previous changes
- block frames are joined by concatenation
- if the session id changes everything is overwritten and reset

When sending a message, one or more frames are joined together, and sent with the local session id, and the starting and ending frame. 

When a message is received, the local copy of the other peers wantlist is rewound to the start frame as necessary, then deltas are applied. (block sends are less important to rewind cause there's no need re-absorb blocks). The change is not applied if the last received frame is less than the starting frame of the incoming message (it may be kept around temporarily in case the missing in between message is received).

A peer also attaches an acknowledgement of the last received remote session id, and the last received remote frame whenever it sends a message. A peer should never send a frame that is less than the lack acknowledged frame (or there's no point in doing so). The lack of any acknowledgement in a message is an indication a peer does not support error correction and the protocol should be downgraded to BS 1.1. The lack of the acknowledged frame advancing means there has been a lost message and old changes should be aggregated and resent. 