### PR TITLE
docs: adds spec sections for mode and mtime metadata

### DIFF
--- a/UNIXFS.md
+++ b/UNIXFS.md
@@ -16,7 +16,6 @@ Draft work and discussion on a specification for the upcoming version 2 of the U
 - [Implementations](#implementations)
 - [Data Format](#data-format)
 - [Metadata](#metadata)
-	- [Inheritance](#inheritance)
 	- [Deduplication and inlining](#deduplication-and-inlining)
 - [Importing](#importing)
 	- [Chunking](#chunking)
@@ -90,10 +89,6 @@ UnixFS currently supports two optional metadata fields:
   The next three least significant bits represent `setuid`, `setgid` and the `sticky bit`
   All others are reserved for future use
 * `mtime` -- The modification time in seconds since the epoch. This defaults to the unix epoch if unspecified
-
-### Inheritance
-
-When traversing down through a UnixFSv1.5 directory, child entries without metadata fields will inherit those of their direct ascendants.
 
 ### Deduplication and inlining
 

--- a/UNIXFS.md
+++ b/UNIXFS.md
@@ -84,8 +84,12 @@ The serialized size of a UnixFS node must not exceed 256KiB in order to work wil
 
 UnixFS currently supports two optional metadata fields:
 
-* `mode` -- The `mode` is for persisting the [file permissions in numeric notation](https://en.wikipedia.org/wiki/File_system_permissions#Numeric_notation) \[[spec](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_stat.h.html)\]. If unspecified this defaults to `0755` for directories/HAMT shards and `0644` for all other types where applicable.
-* `mtime` -- The modification time in seconds since the epoch. This defaults to the unix epoch if unspecified.
+* `mode` -- The `mode` is for persisting the file permissions in [numeric notation](https://en.wikipedia.org/wiki/File_system_permissions#Numeric_notation) \[[spec](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_stat.h.html)\].
+  If unspecified this defaults to `0755` for directories/HAMT shards and `0644` for all other types where applicable
+  The nine least significant bits represent  `ugo-rwx`
+  The next three least significant bits represent `setuid`, `setgid` and the `sticky bit`
+  All others are reserved for future use
+* `mtime` -- The modification time in seconds since the epoch. This defaults to the unix epoch if unspecified
 
 ### Inheritance
 
@@ -147,7 +151,7 @@ This was ultimately rejected for a number of reasons:
 
 	For example many files are under the 256KiB block size limit, so we tend to inline them into the describing UnixFS `File` node.  This would not be possible with an intermediate `Metadata` node.
 
-1. The `File` node already contains some metadata (e.g. the file size) so you'd end up with metadata stored in multiple places
+2. The `File` node already contains some metadata (e.g. the file size) so metadata would be stored in multiple places which complicates forwards compatibility with UnixFSv2 as to map between metadata formats potentially requires multiple fetch operations
 
 #### Metadata in the directory
 

--- a/UNIXFS.md
+++ b/UNIXFS.md
@@ -77,8 +77,6 @@ This data is serialized and placed inside the 'Data' field of the outer merkleda
 
 For files comprised of a single block, the 'Type' field will be set to 'File', 'filesize' will be set to the total number of bytes in the file and the file data will be stored in the 'Data' field.
 
-The serialized size of a UnixFS node must not exceed 256KiB in order to work will with the [Bitswap] protocol.
-
 ## Metadata
 
 UnixFS currently supports two optional metadata fields:
@@ -97,8 +95,6 @@ Where the file data is small it would normally be stored in the `Data` field of 
 To aid in deduplication of data even for small files, file data can be stored in a separate node linked to from the `File` node in order for the data to have a constant [CID] regardless of the metadata associated with it.
 
 As a further optimization, if the `File` node's serialized size is small, it may be inlined into its v1 [CID] by using the [`identity`](https://github.com/multiformats/multicodec/blob/master/table.csv) [multihash].
-
-Such [CID]s must consist of 23 bytes or fewer in order for them to fit inside the 63 character limit for a DNS label when encoded in base32 (see [RFC1035 Section 2.3.1](https://tools.ietf.org/html/rfc1035#section-2.3.1)).
 
 ## Importing
 


### PR DESCRIPTION
Following our Redux Redux meeting, here's what we decided (as I recall).  It largely swings back towards #220 with added sections on deduping and inlining and is more specific about the sizes of things.

The spec is updated with metadata implementation details and a decision rationale section has been added at the end.

Follows on from/supersedes #223