### PR TITLE
docs: change mode and mtime to messages

### DIFF
--- a/UNIXFS.md
+++ b/UNIXFS.md
@@ -60,12 +60,20 @@ message Data {
 	repeated uint64 blocksizes = 4;
 	optional uint64 hashType = 5;
 	optional uint64 fanout = 6;
-	optional uint32 mode = 7;
-	optional int64 mtime = 8;
+	optional Mode mode = 7;
+	optional Mtime mtime = 8;
 }
 
 message Metadata {
 	optional string MimeType = 1;
+}
+
+message Mode {
+	required uint32 value = 1;
+}
+
+message Mtime {
+	required int64 seconds = 1;
 }
 ```
 
@@ -82,7 +90,6 @@ For files comprised of a single block, the 'Type' field will be set to 'File', '
 UnixFS currently supports two optional metadata fields:
 
 * `mode` -- The `mode` is for persisting the file permissions in [numeric notation](https://en.wikipedia.org/wiki/File_system_permissions#Numeric_notation) \[[spec](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_stat.h.html)\].
-  If unspecified this defaults to `0755` for directories/HAMT shards and `0644` for all other types where applicable
   The nine least significant bits represent  `ugo-rwx`
   The next three least significant bits represent `setuid`, `setgid` and the `sticky bit`
   All others are reserved for future use


### PR DESCRIPTION
As currently defined the closest we can come to removing a `mode`/`mtime` previously set on a file is to set it's value to 0, which works in that the CID returns to what it would have been pre-metadata, but when combined with default file/dir modes also has the side effect of making it impossible to actually set the file mode to `0`.

Worse, if you set the file mode to `0` you actually get the default file mode back of `0644` which is probably not what you intended.

The proposed solution is to store `mode`  and `mtime` values in dedicated protobuf messages in order to represent the case where they have not been set.

The protobuf spec [says](https://developers.google.com/protocol-buffers/docs/proto3#default):

> For message fields, the field is not set. Its exact value is language-dependent.

So we are free to represent them as `undefined` when they have not been set.

`mtime` is changed too because if I add some metadata to a file, I should be able to remove it - it shouldn't be a one-way thing.

This PR also removes the default mode values as otherwise it's not an opt-in upgrade.