### PR TITLE
Proposal for dealing with fractional mtime

### DIFF
--- a/UNIXFS.md
+++ b/UNIXFS.md
@@ -94,7 +94,7 @@ UnixFS currently supports two optional metadata fields:
   - If no mtime value is available, an `undefined` mtime is assumed. Implementations are free to default to the epoch itself, or if appropriate render a variant of `N/A` to signify lack of a value
   - If one mtime value is available, it represents the amount of seconds after or *before* the epoch. Implementations must be able to gracefully handle negative mtime, even if such a value is not applicable within their domain ( e.g. a POSIX filesystem )
   - If two mtime values are available, the first one is interpreted as described above, and the second value represents the fractional part of the mtime as the amount of nanoseconds. The valid range for this value is the intger range `[1, 999999999]`.
-    If a fractional part outside of this range is encountered, implementations should consider the entire metadata block invalid and abort processing it. Note that **a fractional value of `0` is NOT invalid**.
+    If a fractional part outside of this range is encountered, implementations should consider the entire metadata block invalid and abort processing it. Note that **a fractional value of `0` is NOT valid**.
   - If more than two repeated mtime values are available, implementations should consider the entire metadata block invalid and abort processing it.
 
 ### Deduplication and inlining

--- a/UNIXFS.md
+++ b/UNIXFS.md
@@ -61,7 +61,7 @@ message Data {
 	optional uint64 hashType = 5;
 	optional uint64 fanout = 6;
 	optional uint32 mode = 7;
-	optional int64 mtime = 8;
+	repeated int64 mtime = 8;
 }
 
 message Metadata {
@@ -90,7 +90,12 @@ UnixFS currently supports two optional metadata fields:
   - The remaining 20 bits are reserved for future use, and are subject to change. Spec implementations **MUST** handle bits they do not expect as follows:
     - For future-proofing the (de)serialization layer must preserve the entire uint32 value during clone/copy operations, modifying only bit values that have a well defined meaning: `clonedValue = ( modifiedBits & 07777 ) | ( originalValue & 0xFFFFF000 )`
     - Implementations of this spec must proactively mask off bits without a defined meaning in the implemented version of the spec: `interpretedValue = originalValue & 07777`
-* `mtime` -- The modification time in seconds since the epoch. This defaults to the unix epoch if unspecified
+* `mtime` -- The modification time in seconds since the epoch `1970-01-01T00:00:00Z`. The `repeated` protobuf type is overloaded to provide optional high resolution as follows:
+  - If no mtime value is available, an `undefined` mtime is assumed. Implementations are free to default to the epoch itself, or if appropriate render a variant of `N/A` to signify lack of a value
+  - If one mtime value is available, it represents the amount of seconds after or *before* the epoch. Implementations must be able to gracefully handle negative mtime, even if such a value is not applicable within their domain ( e.g. a POSIX filesystem )
+  - If two mtime values are available, the first one is interpreted as described above, and the second value represents the fractional part of the mtime as the amount of nanoseconds. The valid range for this value is the intger range `[1, 999999999]`.
+    If a fractional part outside of this range is encountered, implementations should consider the entire metadata block invalid and abort processing it. Note that **a fractional value of `0` is NOT invalid**.
+  - If more than two repeated mtime values are available, implementations should consider the entire metadata block invalid and abort processing it.
 
 ### Deduplication and inlining
 


### PR DESCRIPTION
(ab)use the repeated type to have an identical wire-level representation
without using too many field numbers ( we are already half way through the
15 easy-ones available )