### PR TITLE
Bitswap 1.3.0 - Tokens (and auth) support

### DIFF
--- a/BITSWAP.md
+++ b/BITSWAP.md
@@ -38,6 +38,7 @@ There are multiple Bitswap versions and more may evolve over time. We give brief
 - `/ipfs/bitswap/1.0.0` - Initial version
 - `/ipfs/bitswap/1.1.0` - Support CIDv1
 - `/ipfs/bitswap/1.2.0` - Support Wantlist Have's and Have/DontHave responses
+- `/ipfs/bitswap/1.3.0` - Support adding tokens in Bitswap requests/responses and BlockTooBig error message
 
 ## Bitswap 1.0.0
 
@@ -193,6 +194,94 @@ message Message {
   repeated Block payload = 3;
   repeated BlockPresence blockPresences = 4;
   int32 pendingBytes = 5;
+}
+```
+
+## Bitswap 1.3.0
+
+Bitswap 1.3.0 extends the Bitswap 1.2.0 protocol with the following changes:
+1. Having a list of tokens that may be sent with the message and referenced within the message
+2. Allowing each entry in the wantlist to contain a set of tokens
+3. Allowing responses (both BlockPresences and Blocks) to contain a set of tokens
+4. Adding an `AuthRequired` BlockPresence
+5. Adding a `BlockTooBig` BlockPresence
+
+### Interaction Pattern
+
+Given that a client C wants to fetch data from some server S:
+
+1. C opens a stream `s_want` to S and sends a message for the blocks it wants
+    1. C may either send a complete wantlist, or an update to an outstanding wantlist
+    2. C may reuse this stream to send new wants
+    3. For each of the items in the wantlist C may ask if S has the block (i.e. a Have request) or for S to send the block (i.e. a block request). C may also ask S to send back a DontHave message in the event it doesn't have the block
+    4. For each of the items in the wantlist C may append any `tokens` they want. Recommended tokens include those that would convince S to give C the blocks they want.
+2. S responds back on a stream `s_receive`. S may reuse this stream to send back subsequent responses
+    1. If C sends S a Have request for data S has (and is willing to give to C) it should respond with a Have, although it may instead respond with the block itself (e.g. if the block is very small)
+        1. For each of the items that S sends back Blocks or BlockPresences for they may append any `tokens` they want
+    2. If C sends S a Have request for data S has but is not currently willing to give to C, S may respond with an `AuthRequired` BlockPresence
+      1. For each of the items that S sends back Blocks or BlockPresences for they may append any `tokens` they want. Recommended tokens include those that would inform C how they could convince S to give them access to the blocks they want.
+    2. If C sends S a Have request for data S does not have (or has but is not willing to tell C it has) and C has requested for DontHave responses then S should respond with DontHave
+    3. S may choose to include the number of bytes that are pending to be sent to C in the response message
+    4. If C asked for a block that S has but it is bigger than the maximum block size it should return `BlockTooBig`
+3. When C no longer needs a block it previously asked for it should send a Cancel message for that request to any peers that have not already responded about that particular block. It should particularly send Cancel messages for Block requests (as opposed to Have requests) that have not yet been answered.
+
+### Tokens
+
+The major change in this protocol version is the introduction of the ability to pass tokens along with requests and responses. A token is defined as `<multicode><data>` where the multicode is an identifier in the multicodec table, and the data is token-specific data associated with that code.
+
+Users who require additional codes for their new token formats should do one of:
+- Register their code in the table
+- For non-deployed testing purposes only - use a code in the application reserved range of the code table
+   - Note: if codes in the application reserved range will not be reservable in the code table which means that the code may conflict with another one used in the ecosystem which could cause application problems on collision. It is high recommended to not use these codes outside of testing or early development.
+
+To save space within the message the list of tokens used within the message are declared within the top level message and all other references to tokens are instead to the indices within the token list in the top level message.
+
+### Wire Format
+
+```
+message Message {
+
+  message Wantlist {
+    enum WantType {
+      Block = 0;
+      Have = 1;
+    }
+
+    message Entry {
+      bytes block = 1; // CID of the block
+      int32 priority = 2;	// the priority (normalized). default to 1
+      bool cancel = 3; // whether this revokes an entry
+      WantType wantType = 4; // Note: defaults to enum 0, ie Block
+      bool sendDontHave = 5; // Note: defaults to false
+      repeated tokens int32 = 6; // the indices of the tokens in the token list
+		}
+
+    repeated Entry entries = 1;	// a list of wantlist entries
+    bool full = 2; // whether this is the full wantlist. default to false
+  }
+  message Block {
+    bytes prefix = 1; // CID prefix (all of the CID components except for the digest of the multihash)
+    bytes data = 2;
+    repeated tokens int32 = 3; // the indices of the tokens in the token list
+  }
+
+  enum BlockPresenceType {
+    Have = 0;
+    DontHave = 1;
+    AuthRequired = 2;
+    BlockTooBig = 3;
+  }
+  message BlockPresence {
+    bytes cid = 1;
+    BlockPresenceType type = 2;
+    repeated tokens int32 = 3; // the indices of the tokens in the token list
+  }
+
+  Wantlist wantlist = 1;
+  repeated Block payload = 3;
+  repeated BlockPresence blockPresences = 4;
+  int32 pendingBytes = 5;
+  repeated bytes tokens = 6; // Each token is of the form <multicode><token-data> where the multicode identifies what the data is for
 }
 ```
 


### PR DESCRIPTION
This is a spec proposal continuing from #260 and other issues related to support for authentication, payments, etc. in Bitswap. This builds off of #269 which helps clean up the Bitswap spec a bit and bring it up to date.

The main thrust of the proposal is support for adding a set of tokens to requests and responses to allow metadata. These tokens can convey various application specific requirements or interactions 

A bonus component added to the proposal is adding a `BlockTooBig` type of `BlockPresence` so that proper error messages can be communicated for that use case rather than either causing a stream reset or something more confusing like returning a Have, DontHave, or not responding at all.

This kind of change has been needed for a while, and while this may not resolve everything it seems like it will help us to have a concrete proposal to critique and improve.

cc some folks who have been asking about this for a while: @Stebalien @ianopolous @csuwildcat @obo20 @carsonfarmer @bmann

---

I'll give some background and pre-empt some questions here. If any of this is interesting enough to put in the spec we can do so there.

Unfortunately, GH is pretty bad at threaded discussions not tied to a particular piece of code so if you have a comment about something not explicitly in the code just grab some empty line in the PR and start a thread there.

## Background

In Bitswap versions 1.2.0 and earlier it is not feasible for a server to decide on whether a peer is authorized to receive a particular block of data other than by discriminating on the peer itself. Consider if Alice wants to request a block B from Bob he will serve it to her if she is on his allowlist, and otherwise will not. If Alice wants to gain authorization to download B she can use some external protocol `/authproto` to negotiate her authorization for B with Bob.

This precludes a number of use cases including:
- Multiple auth mechanisms per peer
    - Multitenancy: If Alice was a multitenancy client that was trying to download data from Bob on behalf of Charlie and Dan she doesn't have a good way to know which of Charlie or Dan are supposed to have access to B which means she could be handing over B to Dan even though he shouldn't have been given it in the first place. This might be very useful for semi-trusted intermediaries that are able to download data via Bitswap on behalf of users in more restrictive environments.
    - Per Retrieval Payments: Similar issues arise in the case of Alice and Bob trying to negotiate payments for the retrieval of chunks of two DAGs D1 and D2 both of which contain the block B. When Bob sends Alice B if payments occur after receipt then Alice doesn't know if Bob is expecting to be paid the D1 or the D2 payment rate for B. While probably Bob should just charge whichever is lesser, if the payment scheme is more complicated this might be non-obvious or generally determinable
- Using auth as a fallback: i.e. trying to fetch data without auth before falling back to using auth
    - If Bob has B and Alice asks for it but is not yet authorized there is no way for Bob to communicate the difference between "I don't have the data" and "I have the data but you need to authorization" if he so chooses. This is particularly problematic in the case where the authorization is open (e.g. anyone who wants to pay for the data, anyone who solves a CAPTCHA, etc.) since then the options are to not believe any DONT_HAVEs and waste resources negotiating authorization or for Alice not be able to download data from any peer she didn't know in advance she needed to authenticate with
    
## Alternatives/FAQs

- Why not remove the `AuthRequired` token and instead put auth requirements in the content routing system?
    - Requires going to the content routing system frequently (potentially for every block) to figure out if authorization is required which defeats the important Bitswap optimization of skipping content routing by asking connected peers if they can send us blocks
    - Requires content routing systems to support the auth mechanisms which is a bigger ask than if it could be done at the exchange layer
- Why support arbitrary token types?
    -  Proposals like #260 that do not differentiate different token types make it difficult for the application layer to know what to do with the tokens it received. It may have to do some testing on the tokens to figure out what they are for. It may also lead to ambiguity when a token could be used for two separate authentication schemes
    - IMO a generally useful piece of multiformats is that for the low cost of a few bytes you can figure out what your data is, that seems like something to take advantage of here
- Why not dictate exactly what tokens can/should be used for?
    - Mostly because application developers will do whatever they want here anyway unless it explicitly breaks the protocol. We should give guidance, but any MUSTs here are likely pipe-dreams even if we wanted them
- Why is there a level of indirection around tokens and token indices?
    - Basically to save bytes since we're not using something like gzip on the messages. It is expected that certain scenarios will have many blocks reuse the same tokens and we can save a lot of bytes there, while not being too costly in the one-token-per-block case