### PR TITLE
generalize content-type in reframe spec

### DIFF
--- a/REFRAME.md
+++ b/REFRAME.md
@@ -40,7 +40,7 @@ Given that a client C wants to request information from some server S:
 
 ### HTTP + DAG-JSON
 
-All messages MUST be encoded as DAG-JSON and use explicit content type `application/vnd.ipfs.reframe+dag-json; version=1`
+All messages MUST be encoded as DAG-JSON and use explicit content type `application/vnd.ipfs.http+dag-json; version=1`
 
 
 Requests MUST be sent as HTTP POST requests. If a server supports HTTP/1.1, then it MAY send chunked-encoded messages. Clients supporting HTTP/1.1 MUST accept chunked-encoded responses.

--- a/REFRAME.md
+++ b/REFRAME.md
@@ -40,7 +40,7 @@ Given that a client C wants to request information from some server S:
 
 ### HTTP + DAG-JSON
 
-All messages MUST be encoded as DAG-JSON and use explicit content type `application/vnd.ipfs.http+dag-json; version=1`
+All messages MUST be encoded as DAG-JSON and use explicit content type `application/vnd.ipfs.rpc+dag-json; version=1`
 
 
 Requests MUST be sent as HTTP POST requests. If a server supports HTTP/1.1, then it MAY send chunked-encoded messages. Clients supporting HTTP/1.1 MUST accept chunked-encoded responses.


### PR DESCRIPTION
I think the content-type in the REFRAME API spec should not be viewed as a part of the specific REFRAME API, but rather as a part of the RPC networking framework that the REFRAME API uses. I.e. there may be other APIs that use the same networking RPC stack. Consequently, the content-type should identify the networking framework itself rather than make a reference to the reframe API. So I am proposing we rename it from `application/vnd.ipfs.reframe+dag-json; version=1` to `application/vnd.ipfs.http+dag-json; version=1`.