### PR TITLE
Change IPRS to IPNS in API_CORE.md

### DIFF
--- a/API_CORE.md
+++ b/API_CORE.md
@@ -117,7 +117,7 @@ TODO
   - filters add
   - filters rm
   - peers
-- records (iprs)
+- records (ipns)
   - put
   - get
 


### PR DESCRIPTION
I was searching for IPRS to see if I could find the originally stated reason for record expiration in the IPNS spec, ended up finding a mention of IPRS in this doc instead.