### PR TITLE
Reframe peer records

### DIFF
--- a/REFRAME.md
+++ b/REFRAME.md
@@ -76,6 +76,7 @@ type Request union {
     | "FindProvidersRequest" FindProvidersRequest
     | "GetIPNSRequest" GetIPNSRequest
     | "PutIPNSRequest" PutIPNSRequest
+    | "GetPeerAddressesRequest" GetPeerAddressesRequest
 }
 ```
 
@@ -87,6 +88,7 @@ type Response union {
     | "FindProvidersResponse" FindProvidersResponse
     | "GetIPNSResponse" GetIPNSResponse
     | "PutIPNSResponse" PutIPNSResponse
+    | "GetPeerAddressesResponse" GetPeerAddressesResponse
     | "Error" Error
 }
 ```
@@ -278,6 +280,45 @@ Request:
 Response:
 ```
 {"PutIPNSResponse : {}"}
+```
+
+#### GetPeerAddresses
+
+A message for getting the addresses of a libp2p peer
+
+```ipldsch
+    type GetPeerAddressesRequest struct {
+        ID Bytes # libp2p PeerID
+        RecordTypes [String]
+    }
+
+    type Multiaddresses [Bytes] # Each element in the list is the binary representation of a complete multiaddr without a peerID suffix
+    type Libp2pSignedPeerRecord Bytes # https://github.com/libp2p/specs/blob/8c967a22bfbaff1ae41072b358fdba7c5883b6a4/RFC/0003-routing-records.md
+
+    type PeerRecordType union {
+     | Multiaddresses "multiaddrs"
+     | Libp2pSignedPeerRecord "769" // the libp2p signed peer record entry interpreted as decimal https://github.com/multiformats/multicodec/blob/f5dd49f35b26b447aa380e9a491f195fd49d912c/table.csv#L129
+     | Any default
+    } representation keyed
+    
+    type GetPeerAddressesResponse struct {
+        Records [PeerRecordType]
+    }
+```
+
+##### DAG-JSON Examples
+
+Request: // TODO
+```
+{"GetPeerAddressesRequest" : {
+    "ID" : {"/":{"bytes":"AXIUBPnagss"}},
+    "Record" : {"/":{"bytes":"AXIUBPnagss"}}
+}}
+```
+
+Response: // TODO
+```
+{"GetPeerAddressesResponse : {}"}
 ```
 
 # Method Upgrade Paths

--- a/REFRAME.md
+++ b/REFRAME.md
@@ -173,8 +173,8 @@ Note: While the Key is a CID it is highly recommended that server implementation
     }
 
     type TransferProtocol union {
-        | Bitswap "2304" # Table entry interpretted as decimal string https://github.com/multiformats/multicodec/blob/f5dd49f35b26b447aa380e9a491f195fd49d912c/table.csv#L133
-        | GraphSync-FILv1 "2320" # Table entry interpretted as decimal string https://github.com/multiformats/multicodec/blob/f5dd49f35b26b447aa380e9a491f195fd49d912c/table.csv#L134
+        | Bitswap "2304" # Table entry interpreted as decimal string https://github.com/multiformats/multicodec/blob/f5dd49f35b26b447aa380e9a491f195fd49d912c/table.csv#L133
+        | GraphSync-FILv1 "2320" # Table entry interpreted as decimal string https://github.com/multiformats/multicodec/blob/f5dd49f35b26b447aa380e9a491f195fd49d912c/table.csv#L134
         | Any default
     } representation keyed 
     


### PR DESCRIPTION
WIP but wanted to put out an initial draft for some thoughts and discussion.

## Background

The Reframe protocol gives us a way to build request-response protocols across multiple transports in a data format agnostic way. The first target use case of this protocol was to be able to handle delegated operation of the various types of requests that the IPFS Public DHT handles. At the moment getting provider records as well as putting and getting IPNS records are supported. The remaining function that can be fully delegated to a third party DHT client is getting peer records (putting provider records and peer records into the DHT are not performable in a delegated way due to protocol limitations described in https://github.com/libp2p/go-libp2p-kad-dht/issues/584).

## Motivation

Enabling Reframe to support getting peer records will allow us to start building tooling like a standalone delegated routing server that allows consumers of content to delegate their requests to the server which in turn can query the IPFS Public DHT, Indexers, or any other routing system. More functions will still need to be added going forward to support users who want to make themselves or their content available using this protocol, but those can come later.

## Proposal

The simplest proposal here would be to just have a method that requests the multiaddresses for a given PeerID. However, given that [libp2p signed peer records](https://github.com/libp2p/specs/blob/8c967a22bfbaff1ae41072b358fdba7c5883b6a4/RFC/0003-routing-records.md) are prevalent in the network it should be possible for peers to get those as well and choose to prioritize them if available.

Unfortunately, the libp2p signed peer records are signed protobufs which means: 1) they're not particularly Reframe "friendly" even though we could just send them as bytes 2) we can't reformat the data in a Reframe friendly way because the encoded protobuf is signed and the way in which the data is encoded into the protobuf is non-canonical.

The initial proposal allows the responder send back both unsigned lists of multiaddresses and opaque signed peer records