### PR TITLE
reframe: cacheable GET endpoint for HTTP transport

### DIFF
--- a/REFRAME.md
+++ b/REFRAME.md
@@ -54,7 +54,7 @@ Requests MUST be sent as either:
   - Ephemeral HTTP `POST` request with message passed as DAG-JSON in HTTP request body
   - Suitable for bigger messages, and when HTTP caching should be skipped for the most fresh results
 
-Severs MUST support `GET` for methods marked as cacheable and MUST support `POST` for methods marked as non-cacheable.
+Severs MUST support `GET` for methods marked as cacheable and MUST support `POST` for all methods (both cacheable and not-cacheable). This allows clients to use `POST` as a fallback in case there is a technical problem with bigger Reframe messages not fitting in a `GET` URL.
 
 If a server supports HTTP/1.1, then it MAY send chunked-encoded messages. Clients supporting HTTP/1.1 MUST accept chunked-encoded responses.
 
@@ -156,24 +156,19 @@ Every message except the Error type should end in Request/Response.
 
 #### Cachable/Non-Cachable Methods
 
-The following methods are cachable:
+The following method responses are _cachable_:
 
 ```ipldsch
-type Request union {
+type CachableRequest union {
     | "IdentifyRequest" IdentifyRequest
     | "FindProvidersRequest" FindProvidersRequest
     | "GetIPNSRequest" GetIPNSRequest
 }
 ```
 
-The following methods are non-cachable:
+Methods that are not listed above are considered _non-cachable_.
 
-```ipldsch
-type Request union {
-    | "PutIPNSRequest" PutIPNSRequest
-}
-```
-
+Implementations are encouraged to improve performance of  `CachableRequest` methods by applying transport and method-specific caching strategies.
 #### Error
 
 The Error message type should be used in Responses to indicate that an error has occurred.

--- a/REFRAME.md
+++ b/REFRAME.md
@@ -97,6 +97,23 @@ HTTP header, allowing clients to send conditional requests with
 [`If-Modified-Since`](https://httpwg.org/specs/rfc7232.html#header.if-modified-since)
 header to specify their acceptance for stale (cached) responses.
 
+**Rate-limiting non-cachable POST requests**
+
+HTTP endpoint can return status code
+[429 Too Many Requests](https://www.rfc-editor.org/rfc/rfc6585#section-4)
+with `Retry-After` header to throttle the number of `POST` requests a client can send.
+
+The body returned with `429` response should suggest use of HTTP `GET` endpoint
+for cacheable Reframe methods:
+
+```
+HTTP/1.1 429 Too Many Requests
+Content-Type: text/plain
+Retry-After: 3600
+
+too many POST requests: consider switching to cachable GET or try again later (see Retry-After header)
+```
+
 ## Protocol Message Overview
 
 We can represent each message as an IPLD Schema to denote its abstract representation independent of the serialization scheme. 

--- a/REFRAME.md
+++ b/REFRAME.md
@@ -36,6 +36,10 @@ Given that a client C wants to request information from some server S:
 1. C opens sends a request to S that is a single message
 2. S will respond to C with either a single message or a group of messages
 
+## Cachability
+
+Some methods are prone to being cachable while others are not. Methods are tagged within the spec as cachable/not cachable. Transports may leverage that information to decide if cachable/not cachable methods should be treated differently.
+
 ## Transports
 
 ### HTTP + DAG-JSON
@@ -49,6 +53,8 @@ Requests MUST be sent as either:
 - `POST /reframe`
   - Ephemeral HTTP `POST` request with message passed as DAG-JSON in HTTP request body
   - Suitable for bigger messages, and when HTTP caching should be skipped for the most fresh results
+
+Severs MUST support `GET` for methods marked as cacheable and MUST support `POST` for methods marked as non-cacheable.
 
 If a server supports HTTP/1.1, then it MAY send chunked-encoded messages. Clients supporting HTTP/1.1 MUST accept chunked-encoded responses.
 
@@ -130,6 +136,26 @@ type Response union {
 
 Note: Each Request type has a corresponding Response type.
 Every message except the Error type should end in Request/Response.
+
+#### Cachable/Non-Cachable Methods
+
+The following methods are cachable:
+
+```ipldsch
+type Request union {
+    | "IdentifyRequest" IdentifyRequest
+    | "FindProvidersRequest" FindProvidersRequest
+    | "GetIPNSRequest" GetIPNSRequest
+}
+```
+
+The following methods are non-cachable:
+
+```ipldsch
+type Request union {
+    | "PutIPNSRequest" PutIPNSRequest
+}
+```
 
 #### Error
 

--- a/reframe/README.md
+++ b/reframe/README.md
@@ -1,0 +1,5 @@
+# Reframe Specifications
+
+- [`REFRAME_PROTOCOL.md`](./REFRAME_PROTOCOL.md) ← start here
+  - [`REFRAME_KNOWN_METHODS.md`](./REFRAME_KNOWN_METHODS.md)
+  - [`REFRAME_HTTP_TRANSPORT.md`](./REFRAME_HTTP_TRANSPORT.md)

--- a/reframe/REFRAME_HTTP_TRANSPORT.md
+++ b/reframe/REFRAME_HTTP_TRANSPORT.md
@@ -76,7 +76,7 @@ header, which will skip when the response message did not change.
 
 ### Client controls for time-based caching
 
-Implementations MUST always return
+Implementations can also return (optional) 
 [`Last-Modified`](https://httpwg.org/specs/rfc7232.html#header.last-modified)
 HTTP header, allowing clients to send conditional requests with
 [`If-Modified-Since`](https://httpwg.org/specs/rfc7232.html#header.if-modified-since)

--- a/reframe/REFRAME_HTTP_TRANSPORT.md
+++ b/reframe/REFRAME_HTTP_TRANSPORT.md
@@ -37,7 +37,8 @@ Requests MUST be sent as either:
   - Ephemeral HTTP `POST` request with message passed as DAG-JSON in HTTP request body
   - Suitable for bigger messages, and when HTTP caching should be skipped for the most fresh results
 
-Severs MUST support `GET` for methods marked as cachable and MUST support `POST` for all methods (both cachable and not-cachable). This allows servers to rate-limit `POST` when cachable `GET` could be used instead, and enables clients to use `POST` as a fallback in case there is a technical problem with bigger Reframe messages not fitting in a `GET` URL. See "Caching Considerations" section.
+Servers MUST support `GET` for methods marked as cachable and MUST support `POST` for all methods (both cachable and not-cachable). This allows servers to rate-limit `POST` when cachable `GET` could be used instead, and enables clients to use `POST` as a fallback in case there is a technical problem with bigger Reframe messages not fitting in a `GET` URL. See "Caching Considerations" section.
+
 
 If a server supports HTTP/1.1, then it MAY send chunked-encoded messages. Clients supporting HTTP/1.1 MUST accept chunked-encoded responses.
 

--- a/reframe/REFRAME_HTTP_TRANSPORT.md
+++ b/reframe/REFRAME_HTTP_TRANSPORT.md
@@ -32,6 +32,7 @@ All messages sent in HTTP body MUST be encoded as DAG-JSON and use explicit cont
 Requests MUST be sent as either:
 - `GET /reframe/{mbase64url-dag-cbor}`
   - Cachable HTTP `GET` requests with message passed as DAG-CBOR in HTTP path segment, encoded as URL-safe [`base64url` multibase](https://docs.ipfs.io/concepts/glossary/#base64url) string
+    - DAG-CBOR in multibase `base64url` is used instead of DAG-JSON because JSON may include characters that are not safe to be used in URLs, and re-encoding JSON in base would take too much space
   - Suitable for sharing links, sending smaller messages, and when a query result MUST benefit from HTTP caching (see _HTTP Caching Considerations_ below).
 - `POST /reframe`
   - Ephemeral HTTP `POST` request with message passed as DAG-JSON in HTTP request body

--- a/reframe/REFRAME_HTTP_TRANSPORT.md
+++ b/reframe/REFRAME_HTTP_TRANSPORT.md
@@ -1,0 +1,103 @@
+# ![](https://img.shields.io/badge/status-wip-orange.svg?style=flat-square) Reframe: HTTP Transport
+
+**Author(s)**:
+- Adin Schmahmann
+- Petar Maymounkov
+- Marcin Rataj
+
+**Maintainer(s)**:
+
+* * *
+
+**Abstract**
+
+The Reframe over HTTP protocol is defining the transport and message
+serialization mechanisms for sending Reframe messages over HTTP `POST` and
+`GET`, and provides guidance for implementers around HTTP caching.
+
+# Organization of this document
+
+- [HTTP Transport Design](#http-transport-design)
+  - [HTTP Caching Considerations](#http-caching-considerations)
+    - [POST vs GET](#post-vs-get)
+    - [Avoiding sending the same response messages twice](#avoiding-sending-the-same-response-messages-twice)
+    - [Client controls for time-based caching](#client-controls-for-time-based-caching)
+    - [Rate-limiting non-cachable POST requests](#rate-limiting-non-cachable-post-requests)
+- [Implementations](#implementations)
+
+# HTTP Transport Design
+
+All messages sent in HTTP body MUST be encoded as DAG-JSON and use explicit content type `application/vnd.ipfs.rpc+dag-json; version=1`
+
+Requests MUST be sent as either:
+- `GET /reframe/{mbase64url-dag-cbor}`
+  - Cachable HTTP `GET` requests with message passed as DAG-CBOR in HTTP path segment, encoded as URL-safe [`base64url` multibase](https://docs.ipfs.io/concepts/glossary/#base64url) string
+  - Suitable for sharing links, sending smaller messages, and when a query result MUST benefit from HTTP caching (see _HTTP Caching Considerations_ below).
+- `POST /reframe`
+  - Ephemeral HTTP `POST` request with message passed as DAG-JSON in HTTP request body
+  - Suitable for bigger messages, and when HTTP caching should be skipped for the most fresh results
+
+Severs MUST support `GET` for methods marked as cachable and MUST support `POST` for all methods (both cachable and not-cachable). This allows servers to rate-limit `POST` when cachable `GET` could be used instead, and enables clients to use `POST` as a fallback in case there is a technical problem with bigger Reframe messages not fitting in a `GET` URL. See "Caching Considerations" section.
+
+If a server supports HTTP/1.1, then it MAY send chunked-encoded messages. Clients supporting HTTP/1.1 MUST accept chunked-encoded responses.
+
+Requests and Responses MUST occur over a single HTTP call instead of the server being allowed to dial back the client with a response at a later time.
+
+If a server chooses to respond to a single request message with a group of messages in the response it should do so as a set of `\n` delimited DAG-JSON messages (i.e. `{Response1}\n{Response2}...`).
+
+Requests and responses MUST come with `version=1` as a _Required Parameter_  in the `Accept` and `Content-Type` HTTP headers.
+
+Note: This version header is what allows the transport to more easily evolve over time (e.g. if it was desired to change the transport to support other encodings than DAG-JSON, utilize headers differently, move the request data from the body, etc.). Not including the version number is may lead to incompatibility with future versions of the transport.
+
+## HTTP Caching Considerations
+
+### POST vs GET
+
+HTTP `POST` requests do not benefit from any preexisting HTTP caching because
+every `POST` response will overwrite the cached resource.
+
+While it is possible to write custom middleware to cache `POST` responses based on
+request body, this is not a standard behavior and is discouraged.
+
+Use of `GET` endpoint is not mandatory, but suggested if a Reframe deployment
+expects to handle the same message query multiple times, and want to leverage
+existing HTTP tooling to maximize HTTP cache hits.
+
+### Avoiding sending the same response messages twice
+
+Implementations MUST always return strong
+[`Etag`](https://httpwg.org/specs/rfc7232.html#header.etag) HTTP header based
+on digest of DAG-JSON response messages. This allows clients to send
+inexpensive conditional requests with
+[`If-None-Match`](https://httpwg.org/specs/rfc7232.html#header.if-none-match)
+header, which will skip when the response message did not change.
+
+### Client controls for time-based caching
+
+Implementations MUST always return
+[`Last-Modified`](https://httpwg.org/specs/rfc7232.html#header.last-modified)
+HTTP header, allowing clients to send conditional requests with
+[`If-Modified-Since`](https://httpwg.org/specs/rfc7232.html#header.if-modified-since)
+header to specify their acceptance for stale (cached) responses.
+
+### Rate-limiting non-cachable POST requests
+
+HTTP endpoint can return status code
+[429 Too Many Requests](https://www.rfc-editor.org/rfc/rfc6585#section-4)
+with `Retry-After` header to throttle the number of `POST` requests a client can send.
+
+The body returned with `429` response should suggest use of HTTP `GET` endpoint
+for cachable Reframe methods:
+
+```
+HTTP/1.1 429 Too Many Requests
+Content-Type: text/plain
+Retry-After: 3600
+
+too many POST requests: consider switching to cachable GET or try again later (see Retry-After header)
+```
+
+
+# Implementations
+
+https://github.com/ipfs/go-delegated-routing

--- a/reframe/REFRAME_KNOWN_METHODS.md
+++ b/reframe/REFRAME_KNOWN_METHODS.md
@@ -10,7 +10,7 @@
 
 **Abstract**
 
-This document is defining known method types and semantics.
+This document is defining known methods (request-response message types) and semantics.
 
 # Organization of this document
 
@@ -59,7 +59,7 @@ Every message except the Error type should end in Request/Response.
 
 ## Cachable/Non-Cachable Methods
 
-The following method responses are _cachable_:
+The following methods (request-response pairs) are _cachable_:
 
 ```ipldsch
 type CachableRequest union {

--- a/reframe/REFRAME_KNOWN_METHODS.md
+++ b/reframe/REFRAME_KNOWN_METHODS.md
@@ -1,4 +1,4 @@
-# ![](https://img.shields.io/badge/status-wip-orange.svg?style=flat-square) Reframe
+# ![](https://img.shields.io/badge/status-wip-orange.svg?style=flat-square) Reframe: Known Methods
 
 **Author(s)**:
 - Adin Schmahmann
@@ -10,123 +10,26 @@
 
 **Abstract**
 
-The Reframe protocol is designed for request-response messages that is sufficiently generic and extensible to evolve over time as new needs for it arise. This includes separately defining the transport and message serialization mechanisms from the actual method types and semantics.
-
-The initial use case motivating the protocol's design is to help peers discover various routing hints that enable them to find the content or service they are actually looking for. The extensibility required in this case is that various routing systems could share the protocol so that applications can work on them generically and that recursive routing systems could choose to use the protocol themselves to maximize interoperability.
+This document is defining known method types and semantics.
 
 # Organization of this document
 
-- [Introduction](#introduction)
-- [Spec](#spec)
-- [Intended Upgrade Paths](#intended-upgrade-paths)
+- [Known Methods](#known-methods)
+  - [Cachable/Non-Cachable Methods](#cachablenon-cachable-methods)
+- [Message Specs](#message-specs)
+  - [Error](#error)
+  - [Identify](#identify)
+    - [DAG-JSON Examples](#dag-json-examples)
+  - [FindProviders](#findproviders)
+    - [DAG-JSON Examples](#dag-json-examples-1)
+  - [GetIPNS](#getipns)
+    - [DAG-JSON Examples](#dag-json-examples-2)
+  - [PutIPNS](#putipns)
+    - [DAG-JSON Examples](#dag-json-examples-3)
+- [Method Upgrade Paths](#method-upgrade-paths)
 - [Implementations](#implementations)
 
-# Introduction
-
-The Reframe protocol is a request-response based protocol. Upon receiving a request a Reframe server should respond to clients with information they have pertaining to the request. It's possible that a Reframe server may not have all of the information necessary for a client to actually get the data they need, but even partial resolution is acceptable. For example, if a peer is looking to download some block of data a Reframe server may only know about some peers that have the data but not their network addresses. That's ok and the client can always choose alternative mechanisms to discover the missing information. 
-
-# Spec
-
-To build an implementation of the protocol it is required to both define a transport for the messages and the method types supported by the given implementation. Over time both the method and transport types may grow and also be included in this specification.
-
-## Interaction Pattern
-
-Given that a client C wants to request information from some server S:
-
-1. C opens sends a request to S that is a single message
-2. S will respond to C with either a single message or a group of messages
-
-## Cachability
-
-Some methods are prone to being cachable while others are not. Methods are tagged within the spec as cachable/not cachable. Transports may leverage that information to decide if cachable/not cachable methods should be treated differently.
-
-## Transports
-
-### HTTP + DAG-JSON
-
-All messages sent in HTTP body MUST be encoded as DAG-JSON and use explicit content type `application/vnd.ipfs.rpc+dag-json; version=1`
-
-Requests MUST be sent as either:
-- `GET /reframe/{mbase64url-dag-cbor}`
-  - Cacheable HTTP `GET` requests with message passed as DAG-CBOR in HTTP path segment, encoded as URL-safe [`base64url` multibase](https://docs.ipfs.io/concepts/glossary/#base64url) string
-  - Suitable for sharing links, sending smaller messages, and when a query result MUST benefit from HTTP caching (see _HTTP Caching Considerations_ below).
-- `POST /reframe`
-  - Ephemeral HTTP `POST` request with message passed as DAG-JSON in HTTP request body
-  - Suitable for bigger messages, and when HTTP caching should be skipped for the most fresh results
-
-Severs MUST support `GET` for methods marked as cacheable and MUST support `POST` for all methods (both cacheable and not-cacheable). This allows clients to use `POST` as a fallback in case there is a technical problem with bigger Reframe messages not fitting in a `GET` URL.
-
-If a server supports HTTP/1.1, then it MAY send chunked-encoded messages. Clients supporting HTTP/1.1 MUST accept chunked-encoded responses.
-
-Requests and Responses MUST occur over a single HTTP call instead of the server being allowed to dial back the client with a response at a later time.
-
-If a server chooses to respond to a single request message with a group of messages in the response it should do so as a set of `\n` delimited DAG-JSON messages (i.e. `{Response1}\n{Response2}...`).
-
-Requests and responses MUST come with `version=1` as a _Required Parameter_  in the `Accept` and `Content-Type` HTTP headers.
-
-Note: This version header is what allows the transport to more easily evolve over time (e.g. if it was desired to change the transport to support other encodings than DAG-JSON, utilize headers differently, move the request data from the body, etc.). Not including the version number is may lead to incompatibility with future versions of the transport.
-
-#### HTTP Caching Considerations
-
-**POST vs GET**
-
-HTTP `POST` requests do not benefit from any preexisting HTTP caching because
-every `POST` response will overwrite the cached resource.
-
-While it is possible to write custom middleware to cache `POST` responses based on
-request body, this is not a standard behavior and is discouraged.
-
-Use of `GET` endpoint is not mandatory, but suggested if a Reframe deployment
-expects to handle the same message query multiple times, and want to leverage
-existing HTTP tooling to maximize HTTP cache hits.
-
-**Avoiding sending the same response messages twice**
-
-Implementations MUST always return strong
-[`Etag`](https://httpwg.org/specs/rfc7232.html#header.etag) HTTP header based
-on digest of DAG-JSON response messages. This allows clients to send
-inexpensive conditional requests with
-[`If-None-Match`](https://httpwg.org/specs/rfc7232.html#header.if-none-match)
-header, which will skip when the response message did not change.
-
-**Client controls for time-based caching**
-
-Implementations MUST always return
-[`Last-Modified`](https://httpwg.org/specs/rfc7232.html#header.last-modified)
-HTTP header, allowing clients to send conditional requests with
-[`If-Modified-Since`](https://httpwg.org/specs/rfc7232.html#header.if-modified-since)
-header to specify their acceptance for stale (cached) responses.
-
-**Rate-limiting non-cachable POST requests**
-
-HTTP endpoint can return status code
-[429 Too Many Requests](https://www.rfc-editor.org/rfc/rfc6585#section-4)
-with `Retry-After` header to throttle the number of `POST` requests a client can send.
-
-The body returned with `429` response should suggest use of HTTP `GET` endpoint
-for cacheable Reframe methods:
-
-```
-HTTP/1.1 429 Too Many Requests
-Content-Type: text/plain
-Retry-After: 3600
-
-too many POST requests: consider switching to cachable GET or try again later (see Retry-After header)
-```
-
-## Protocol Message Overview
-
-We can represent each message as an IPLD Schema to denote its abstract representation independent of the serialization scheme. 
-
-To help visualize example messages and illustrate implementation of the first concrete transport (HTTP + DAG-JSON) example messages will be given in DAG-JSON.
-
-The payload sent as a request is a single message. The response is a repeated set of messages until the transport signals that the response is completed (e.g. closing a stream, connection, etc.)
-
-Reception, on the server or client side, of:
-1. New or unknown fields in any request or response message are ignored (rather than causing an error)
-2. Missing fields or unknown union cases cause a terminal error
-
-### Known Methods
+# Known Methods
 
 The known Request types are the following and are described below:
 
@@ -154,7 +57,7 @@ type Response union {
 Note: Each Request type has a corresponding Response type.
 Every message except the Error type should end in Request/Response.
 
-#### Cachable/Non-Cachable Methods
+## Cachable/Non-Cachable Methods
 
 The following method responses are _cachable_:
 
@@ -169,7 +72,10 @@ type CachableRequest union {
 Methods that are not listed above are considered _non-cachable_.
 
 Implementations are encouraged to improve performance of  `CachableRequest` methods by applying transport and method-specific caching strategies.
-#### Error
+
+# Message Specs
+
+## Error
 
 The Error message type should be used in Responses to indicate that an error has occurred.
 
@@ -179,7 +85,7 @@ The Error message type should be used in Responses to indicate that an error has
     }
 ```
 
-#### Identify
+## Identify
 
 A message for discovering which messages a server supports. May be used by applications to optimize which servers get sent which types of requests.
 
@@ -193,7 +99,7 @@ A message for discovering which messages a server supports. May be used by appli
 
 `IdentifyResponse` should return the set of supported methods aside from the "Identify" method.
 
-##### DAG-JSON Examples
+### DAG-JSON Examples
 
 Request:
 ```
@@ -207,7 +113,7 @@ Response:
 }}
 ```
 
-#### FindProviders
+## FindProviders
 
 A message for finding nodes that have an interest in a given key. Some common examples include finding which peers have advertised that they have a given CID, or which peers are interested in a given pubsub topic.
 
@@ -260,7 +166,7 @@ Note: While the Key is a CID it is highly recommended that server implementation
     }
 ```
 
-##### DAG-JSON Examples
+### DAG-JSON Examples
 
 Request:
 ```
@@ -293,7 +199,7 @@ Response:
 }}
 ```
 
-#### GetIPNS
+## GetIPNS
 
 A message for finding the latest IPNS records for a given identifier.
 
@@ -309,7 +215,7 @@ A message for finding the latest IPNS records for a given identifier.
     }
 ```
 
-##### DAG-JSON Examples
+### DAG-JSON Examples
 
 Request:
 ```
@@ -327,7 +233,7 @@ Response:
 }}...
 ```
 
-#### PutIPNS
+## PutIPNS
 
 A message for putting the latest IPNS records for a given identifier.
 
@@ -340,7 +246,7 @@ A message for putting the latest IPNS records for a given identifier.
     type PutIPNSResponse struct {}
 ```
 
-##### DAG-JSON Examples
+### DAG-JSON Examples
 
 Request:
 ```

--- a/reframe/REFRAME_PROTOCOL.md
+++ b/reframe/REFRAME_PROTOCOL.md
@@ -1,0 +1,77 @@
+# ![](https://img.shields.io/badge/status-wip-orange.svg?style=flat-square) Reframe
+
+**Author(s)**:
+- Adin Schmahmann
+- Petar Maymounkov
+
+**Maintainer(s)**:
+
+* * *
+
+**Abstract**
+
+The Reframe protocol is designed for request-response messages that is sufficiently generic and extensible to evolve over time as new needs for it arise. This includes separately defining the transport and message serialization mechanisms from the actual method types and semantics.
+
+The initial use case motivating the protocol's design is to help peers discover various routing hints that enable them to find the content or service they are actually looking for. The extensibility required in this case is that various routing systems could share the protocol so that applications can work on them generically and that recursive routing systems could choose to use the protocol themselves to maximize interoperability.
+
+# Organization of this document
+
+- [Introduction](#introduction)
+- [Spec](#spec)
+  - [Interaction Pattern](#interaction-pattern)
+  - [Cachability](#cachability)
+  - [Transports](#transports)
+  - [Protocol Message Overview](#protocol-message-overview)
+    - [Known Methods](#known-methods)
+- [Method Upgrade Paths](#method-upgrade-paths)
+- [Implementations](#implementations)
+
+# Introduction
+
+The Reframe protocol is a request-response based protocol. Upon receiving a request a Reframe server should respond to clients with information they have pertaining to the request. It's possible that a Reframe server may not have all of the information necessary for a client to actually get the data they need, but even partial resolution is acceptable. For example, if a peer is looking to download some block of data a Reframe server may only know about some peers that have the data but not their network addresses. That's ok and the client can always choose alternative mechanisms to discover the missing information. 
+
+# Spec
+
+To build an implementation of the protocol it is required to both define a transport for the messages and the method types supported by the given implementation. Over time both the method and transport types may grow and also be included in this specification.
+
+## Interaction Pattern
+
+Given that a client `C` wants to request information from some server `S`:
+
+1. `C` opens sends a request to `S` that is a single message
+2. `S` will respond to `C` with either a single message or a group of messages
+
+## Cachability
+
+Some methods are prone to being cachable while others are not. Methods are tagged within the spec as cachable/not cachable. Transports may leverage that information to decide if cachable/not cachable methods should be treated differently.
+
+## Transports
+
+Reframe is designed to be transport-agnostic, multiple transports are expected
+to exist in the future.
+
+Available transport specifications:
+
+- [`REFRAME_HTTP_TRANSPORT`](./REFRAME_HTTP_TRANSPORT.md)
+
+## Protocol Message Overview
+
+We can represent each message as an IPLD Schema to denote its abstract representation independent of the serialization scheme. 
+
+To help visualize example messages and illustrate implementation of the first concrete transport (HTTP + DAG-JSON) example messages will be given in DAG-JSON.
+
+The payload sent as a request is a single message. The response is a repeated set of messages until the transport signals that the response is completed (e.g. closing a stream, connection, etc.)
+
+Reception, on the server or client side, of:
+1. New or unknown fields in any request or response message are ignored (rather than causing an error)
+2. Missing fields or unknown union cases cause a terminal error
+
+### Known Methods
+
+The known Request types are described in:
+
+-  [`REFRAME_KNOWN_METHODS.md`](./REFRAME_KNOWN_METHODS.md)
+
+# Implementations
+
+https://github.com/ipfs/go-delegated-routing


### PR DESCRIPTION
> Closes https://github.com/ipfs/specs/issues/282

Surgical spec tweak that aims to resolve caching problems described in https://github.com/ipfs/specs/issues/282, by providing both GET and POST endpoints (similar to json-rpc) 

- adding `GET /reframe/{mbase64url-dag-cbor}` endpoint for use cases where being able to leverage HTTP caching provides significant value
- adding _HTTP Caching Considerations_ section with
  - POST vs GET explainer
  - `Etag` for avoiding sending same response twice
  - `Last-Modified` as a mechanism for clients to force response freshness 
  
  lmk if this would do
  
@aschmahmann @guseggert  @willscott @thattommyhall @masih – this is by no means "final" – opened this PR to get the conversation started, looking for  an acceptable solution.


## TODO

- [x] <del>TBD POST should  return `Content-Location` with `GET` URL to ensure POST response is still cacheable, under correct GET URL</del>
  - probably better to skip - in most cases this introduces more cost (dual serialization to dag-json and dag-cbort in GET URL) than we get in return from opportunistic cache hits
- [x] split transports to separate REFRAME_TRANSPORTS.md  (and methods like "IPFS PUT" to  REFRAME_METHODS.md ?)
  - split proposed in https://github.com/ipfs/specs/pull/292
- [x] make it clear that we require support for both GET and POST to be implemented   – leaving it to implementation to decide when to use which  based on Reframe method inside of message sent