### PR TITLE
unixfs: suggest, but do not strictly mandate unixfs<>dagpb

### DIFF
--- a/UNIXFS.md
+++ b/UNIXFS.md
@@ -78,7 +78,7 @@ This `Data` object is used for all non-leaf nodes in Unixfs.
 
 For files that are comprised of more than a single block, the 'Type' field will be set to 'File', the 'filesize' field will be set to the total number of bytes in the file (not the graph structure) represented by this node, and 'blocksizes' will contain a list of the filesizes of each child node.
 
-This data is serialized and placed inside the 'Data' field of the outer merkledag protobuf, which also contains the actual links to the child nodes of this object.
+This data is serialized and placed inside the 'Data' _Bytes_ node of the containing IPLD block, which also contains the actual links to the child nodes of this object in a 'Links' _List_ node. Typically this is encoded using the [DAG-PB](https://ipld.io/specs/codecs/dag-pb/spec/) codec. An implementations of this UnixFS specification may opt to strictly link DAG-PB to UnixFS for encoding and/or decoding as this is the originally intended layering of this format. For this reason, producers of UnixFS data that do not use DAG-PB as its codec should not expect other implementations of UnixFS to be able to interpret the data.
 
 For files comprised of a single block, the 'Type' field will be set to 'File', 'filesize' will be set to the total number of bytes in the file and the file data will be stored in the 'Data' field.
 


### PR DESCRIPTION
The strict coupling poses some problems for IPLD implementations that:

 1. do not retain codec information between the serialization and UnixFS (ADL) reification; and/or
 2. do not have a mechanism to strictly mandate that UnixFS data be _only_ encoded in a particular codec.

A mandate in the specification that strictly defines the layering on top of the codec makes it difficult to implement it as an ADL, which also presents difficulty for using tooling that builds on IPLD lens-style layering.

Ref: https://github.com/ipfs/go-unixfsnode/pull/27
Ref: https://github.com/ipfs/specs/pull/271
Ref: https://github.com/ipld/go-car/pull/304

---

So, this is basically a take-two on https://github.com/ipfs/specs/pull/271, but with an extra helping of nuance in an attempt to open the door slightly, but not too far that this complicates life for existing implementations. The main aim here is to _allow for_ the kind of layering approach that we have with go-ipld-prime + ADLs. As per https://github.com/ipld/go-car/pull/304 we already have situations where we have enough distance between block decode and ADL interpret that we can't properly apply a type check. This gives us wriggle-room to pass the data through the generic go-ipld-prime "lens" paradigm and let it come out as UnixFS; _even if_ in practice we tightly couple it when encoding the data and may impose an expectation when decoding, where possible.

But also, it'd be good to have at least the potential for separation so we can treat the UnixFS ADL as a full ADL and not a special-cased beast.

At the same time this PR updates the language of this section to current IPLD parlance.

Any stomach for nuance?