### PR TITLE
gateway: use regular cache-control for CARs

### DIFF
--- a/http-gateways/PATH_GATEWAY.md
+++ b/http-gateways/PATH_GATEWAY.md
@@ -388,10 +388,6 @@ Returned directive depends on requested content path and format:
   - If TTL value is unknown, implementations are free to set it to a static
     value, but it should not be lower than 60 seconds.
 
-- `Cache-Control: no-cache, no-transform`  should be returned with
-  `application/vnd.ipld.car` responses if the block order in CAR stream is not
-  guaranteed to be deterministic.
-
 ### `Last-Modified` (response header)
 
 Optional, used as additional hint for HTTP caching.


### PR DESCRIPTION
> I remember discussing this with some gateway operators, but forgot to fix this before #283  got merged. 

This PR removes special-casing of CAR responses, 
and makes them  follow the same [`Cache-Control` rules](https://github.com/ipfs/specs/blob/main/http-gateways/PATH_GATEWAY.md#cache-control-response-header) as raw blocks and regular files:

> - `Cache-Control: public, max-age=29030400, immutable` must be returned for 
>  every immutable resource under `/ipfs/` namespace.
> - `Cache-Control: public, max-age=<ttl>` should be returned for mutable
>   resources under `/ipns/{id-with-ttl}/`


### Rationale 

This fix already landed in https://github.com/ipfs/go-ipfs/pull/9080 and will be released in kubo 0.14-rc1.

The initial draft used `Cache-Control: no-cache, no-transform` for CARs as a precaution, as desired behavior and response  "determinism"  was unclear.

- Main question was: is behavior in go-ipfs the canonical one, or do we want to allow future  implementers to do more efficient things like return blocks in the (random) order they arrive from datastore?
- Second question: what is lesser evil: caching partial CAR responses (in rare case connection gets dropped mid-stream), or not caching them at all.

After talking with gateway operators, and folks who push CARs over HTTP  the feedback was unanimous: caching CARs the same way regular files/blocks already are is better.

#### Handling partial CAR responses

Regular HTTP practices apply: a client can easily detect partial DAG and fetch missing parts in new requests,  or retry the original one with `Cache-Control: no-cache`. 

#### Handling undefined block order

With regard to "block order" in a CAR, I believe it is already covered by use of weak Etag for CARs: 

> - When a gateway can’t guarantee byte-for-byte identical responses, a “weak”
>   etag should be used. For example, if CAR is streamed, and blocks arrive in
>   non-deterministic order, the response should have `Etag: W/"bafy…foo.car"`

We are still [disabling range requests](https://github.com/ipfs/specs/blob/main/http-gateways/PATH_GATEWAY.md#accept-ranges-response-header) if block order is not deterministic:

> `Accept-Ranges: none` should be returned with `application/vnd.ipld.car` responses if the block order in CAR stream is not deterministic.

With these, there is no need to disable HTTP caching, as CARs will be logically equivalent, and reusing cached response is beneficial.

cc @gmasgras @thattommyhall  @thibmeu  @ribasushi  @mikeal  (just  FYI, no need to respond, I believe we want to maximize HTTP caching of  CAR responses, but lmk if  any concerns)