### PR TITLE
fix: links in  naming/pubsub.md

### DIFF
--- a/naming/pubsub.md
+++ b/naming/pubsub.md
@@ -50,7 +50,7 @@ where base64url-unpadded is an unpadded base64url as specified in [IETF RFC 4648
 
 # Layering persistence onto libp2p PubSub
 
-libp2p PubSub does not have any notion of persistent data built into it. However, we can layer persistence on top of PubSub by utilizing [libp2p Fetch](https://github.com/libp2p/specs/pull/204).
+libp2p PubSub does not have any notion of persistent data built into it. However, we can layer persistence on top of PubSub by utilizing [libp2p Fetch](https://github.com/libp2p/specs/tree/master/fetch).
 
 The protocol has the following steps:
 1. Start State: Node `A` subscribes to the PubSub topic `t` corresponding to the local IPNS record key `k`
@@ -91,4 +91,4 @@ every 10 seconds)
 
 # Implementations
 
-  - <https://github.com/ipfs/go-ipfs/tree/master/namesys>
+  - <https://github.com/ipfs/kubo/tree/master/namesys>

--- a/naming/pubsub.md
+++ b/naming/pubsub.md
@@ -91,4 +91,5 @@ every 10 seconds)
 
 # Implementations
 
-  - <https://github.com/ipfs/kubo/tree/master/namesys>
+  - <https://github.com/ipfs/go-namesys>
+

--- a/naming/pubsub.md
+++ b/naming/pubsub.md
@@ -91,5 +91,5 @@ every 10 seconds)
 
 # Implementations
 
-  - <https://github.com/ipfs/go-namesys>
+  - Kubo:  <https://github.com/ipfs/go-namesys> and <https://github.com/libp2p/go-libp2p-pubsub-router>
 


### PR DESCRIPTION
Link in last line (line 94) is broken. I couldn't find which one it was supposed to be redirected to.