### PR TITLE
chore: improve markdown lint

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,24 +1,28 @@
-name: Lint Markdown
+name: lint
 on:
   workflow_dispatch:
   push:
 
-###############
-# Set the Job #
-###############
 jobs:
-  build:
-    name: Lint Markdown Docs
+  #markdownlint:
+  #  runs-on: ubuntu-latest
+  #  steps:
+  #    - uses: actions/checkout@v2
+  #    - uses: xt0rted/markdownlint-problem-matcher@b643b0751c371f357690337d4549221347c0e1bc # v1.0
+  #    - run: npx markdownlint **/*.md --ignore node_modules
+  super-linter:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           # Full git history is needed to get a proper list of changed files within `super-linter`
           fetch-depth: 0
       - name: Lint
         uses: github/super-linter/slim@v4
         env:
+          LINTER_RULES_PATH: '.'
+          MARKDOWN_CONFIG_FILE: .markdownlint.json
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_MARKDOWN: true
           DEFAULT_BRANCH: main

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,6 @@
+{
+  "single-h1": false,
+  "no-bare-urls": false,
+  "no-emphasis-as-header": false,
+  "line-length": false
+}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+all: superlinter
+
+superlinter:
+	docker run --rm -e VALIDATE_ALL_CODEBASE=false -e RUN_LOCAL=true -e VALIDATE_MARKDOWN=true -e MARKDOWN_CONFIG_FILE=".markdownlint.json" -e LINTER_RULES_PATH="." -v $(shell pwd):/tmp/lint github/super-linter:v4


### PR DESCRIPTION
small quality of life improvements

- [x] adds `Makefile` for running local lint
- [x] adds file which allows us to disable some rules (reduces noise until we have something like #321)
