### PR TITLE
IPIP-327: Reframe over HTTP version=2 (DAG-CBOR and better cache controls)

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,4 +1,5 @@
 {
+  "fenced-code-language": false,
   "single-h1": false,
   "no-bare-urls": false,
   "no-emphasis-as-header": false,

--- a/IPIP/0000-http-reframe-cbor.md
+++ b/IPIP/0000-http-reframe-cbor.md
@@ -29,7 +29,7 @@ We already support DAG-JSON, with its own content type.
 The change here is to add support for requests and responses sent as DAG-CBOR,
 with own content type: `application/vnd.ipfs.rpc+dag-cbor`.
 
-For details, see changes  made to `reframe/REFRAME_HTTP_TRANSPORT.md`
+For details, see changes made to `reframe/REFRAME_HTTP_TRANSPORT.md`.
 
 ## Test fixtures
 
@@ -38,9 +38,9 @@ TODO: add CIDs of sample DAG-CBOR messages after https://github.com/ipfs/go-dele
 ## Design rationale
 
 IPFS stack aims to support both DAG-CBOR and DAG-JSON. Users can store JSON as
-CBOR and vice versa. Having consitent support for both in Reframe not only
+CBOR and vice versa. Having consistent support for both in Reframe not only
 aligns with user expectations, but also allows us to save some bytes
-(bandwidth, response caching requirements) by using a binary CBOR as  the
+(bandwidth, response caching requirements) by using a binary CBOR as the
 production format.
 
 ### User benefit
@@ -63,7 +63,7 @@ N/A, we will use the same DAG-CBOR encoder/decoder as the rest of the stack.
 
 Alternative is to do nothing, and end up with:
 
-- inconsitent user experience
+- inconsistent user experience
 - wasted bandwidth and cache storage
 
 ### Copyright

--- a/IPIP/0000-http-reframe-cbor.md
+++ b/IPIP/0000-http-reframe-cbor.md
@@ -1,0 +1,71 @@
+# IPIP 0000: Add DAG-CBOR support to Reframe over HTTP
+
+<!-- IPIP number will be assigned by an editor. When opening a pull request to
+submit your IPIP, please use number 0000 and an abbreviated title in the filename,
+`0000-draft-title-abbrev.md`. -->
+
+- Start Date: 2022-09-29
+- Related Issues:
+  - https://github.com/ipld/edelweiss/issues/16#issuecomment-1074161577
+  - https://github.com/ipfs/kubo/issues/8823
+
+## Summary
+
+<!--One paragraph explanation of the IPIP.-->
+This IPIP adds DAG-CBOR support to Reframe over HTTP.
+
+## Motivation
+
+We've been using Reframe in Kubo for a while and it is clear that Reframe
+messages are not designed to be created or read by humans.
+
+The plaintext  DAG-JSON representation of messages does not really bring
+anything to the table (because both CIDs and Multiaddrs are in a format that
+needs manual encoding/decoding anyway),
+
+## Detailed design
+
+We already support DAG-JSON, with its own content type.
+The change here is to add support for requests and responses sent as DAG-CBOR,
+with own content type: `application/vnd.ipfs.rpc+dag-cbor`.
+
+For details, see changes  made to `reframe/REFRAME_HTTP_TRANSPORT.md`
+
+## Test fixtures
+
+TODO: add CIDs of sample DAG-CBOR messages after https://github.com/ipfs/go-delegated-routing implements it, and has own tests.
+
+## Design rationale
+
+IPFS stack aims to support both DAG-CBOR and DAG-JSON. Users can store JSON as
+CBOR and vice versa. Having consitent support for both in Reframe not only
+aligns with user expectations, but also allows us to save some bytes
+(bandwidth, response caching requirements) by using a binary CBOR as  the
+production format.
+
+### User benefit
+
+User will be able to choose between binary and human-readable representation,
+just like they do in other parts of IPFS/IPLD stack.
+
+### Compatibility
+
+Explain the upgrade considerations for existing implementations.
+
+This IPIP add DAG-CBOR next to already existing DAG-JSON. Preexisting clients
+that only speak DAG-JSON will continue working, no change is required.
+
+### Security
+
+N/A, we will use the same DAG-CBOR encoder/decoder as the rest of the stack.
+
+### Alternatives
+
+Alternative is to do nothing, and end up with:
+
+- inconsitent user experience
+- wasted bandwidth and cache storage
+
+### Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/reframe/REFRAME_HTTP_TRANSPORT.md
+++ b/reframe/REFRAME_HTTP_TRANSPORT.md
@@ -63,16 +63,20 @@ The rules around implicit content type are as follows:
 
 Requests MUST be sent as either:
 
-- `GET /reframe/{mbase64url-dag-cbor}`
+- `GET /reframe/{CachableRequestMethodName}/{request-as-mbase64url-dag-cbor}`
   - Cachable HTTP `GET` requests with message passed as DAG-CBOR in HTTP path segment, encoded as URL-safe [`base64url` multibase](https://docs.ipfs.io/concepts/glossary/#base64url) string
+    - Cachable method name is placed on the URL path, allowing for different caching strategies per method, and custom routing/scaling per method, if needed.
     - DAG-CBOR in multibase `base64url` is used (even when request body is DAG-JSON) because JSON may include characters that are not safe to be used in URLs, and percent-encoding or base-encoding a big JSON query may take too much space.
   - Suitable for sharing links, sending bigger messages, and when a query result MUST benefit from HTTP caching (see _HTTP Caching Considerations_ below).
-- `GET /reframe?q={percent-encoded-dag-json}`
+  - DAG-CBOR response is the implicit default, unless explicit `Accept` header is passed
+- `GET /reframe?q={percent-encoded-request-as-dag-json}`
   - DAG-JSON is supported via a `?q` query parameter, and the value MUST be [percent-encoded](https://en.wikipedia.org/wiki/Percent-encoding)
   - Suitable for sharing links, sending smaller messages, testing and debugging.
+  - DAG-JSON response is the implicit default, unless explicit `Accept` header is passed
 - `POST /reframe`
-  - Ephemeral HTTP `POST` request with DAG-JSON or DAG-CBOR message passed in HTTP request body
+  - Ephemeral HTTP `POST` request with DAG-JSON or DAG-CBOR message passed in HTTP request body and a mandatory `Content-Type` header informing endpoint how to parse the body
   - Suitable for bigger messages, and when HTTP caching should be skipped for the most fresh results
+  - Response type is the same as request, unless explicit `Accept` header is passed
 
 Servers MUST support `GET` for methods marked as cachable and MUST support `POST` for all methods (both cachable and not-cachable). This allows servers to rate-limit `POST` when cachable `GET` could be used instead, and enables clients to use `POST` as a fallback in case there is a technical problem with bigger Reframe messages not fitting in a `GET` URL. See "Caching Considerations" section.
 

--- a/reframe/REFRAME_HTTP_TRANSPORT.md
+++ b/reframe/REFRAME_HTTP_TRANSPORT.md
@@ -70,8 +70,8 @@ Requests MUST be sent as either:
     - DAG-CBOR in multibase `base64url` is used (even when request body is DAG-JSON) because JSON may include characters that are not safe to be used in URLs, and percent-encoding or base-encoding a big JSON query may take too much space.
   - Suitable for sharing links, sending bigger messages, and when a query result MUST benefit from HTTP caching (see _HTTP Caching Considerations_ below).
   - DAG-CBOR response is the implicit default, unless explicit `Accept` header is passed
-- `GET /reframe/{method}?q={percent-encoded-request-as-dag-json}`
-  - DAG-JSON is supported via a `?q` query parameter, and the value MUST be [percent-encoded](https://en.wikipedia.org/wiki/Percent-encoding)
+- `GET /reframe/{method}?json={percent-encoded-request-as-dag-json}`
+  - DAG-JSON is supported via a `?json` query parameter, and the value MUST be [percent-encoded](https://en.wikipedia.org/wiki/Percent-encoding)
   - Suitable for sharing links, sending smaller messages, testing and debugging.
   - DAG-JSON response is the implicit default, unless explicit `Accept` header is passed
 - `POST /reframe/{method}`

--- a/reframe/REFRAME_HTTP_TRANSPORT.md
+++ b/reframe/REFRAME_HTTP_TRANSPORT.md
@@ -63,17 +63,17 @@ The rules around implicit content type are as follows:
 
 Requests MUST be sent as either:
 
-- `GET /reframe/{CachableRequestMethodName}/{request-as-mbase64url-dag-cbor}`
+- `GET /reframe/{method}/{request-as-mbase64url-dag-cbor}`
   - Cachable HTTP `GET` requests with message passed as DAG-CBOR in HTTP path segment, encoded as URL-safe [`base64url` multibase](https://docs.ipfs.io/concepts/glossary/#base64url) string
-    - Cachable method name is placed on the URL path, allowing for different caching strategies per method, and custom routing/scaling per method, if needed.
+    - Cachable `method` name is placed on the URL path, allowing for different caching strategies per `method`, and custom routing/scaling per `method`, if needed.
     - DAG-CBOR in multibase `base64url` is used (even when request body is DAG-JSON) because JSON may include characters that are not safe to be used in URLs, and percent-encoding or base-encoding a big JSON query may take too much space.
   - Suitable for sharing links, sending bigger messages, and when a query result MUST benefit from HTTP caching (see _HTTP Caching Considerations_ below).
   - DAG-CBOR response is the implicit default, unless explicit `Accept` header is passed
-- `GET /reframe?q={percent-encoded-request-as-dag-json}`
+- `GET /reframe/{method}?q={percent-encoded-request-as-dag-json}`
   - DAG-JSON is supported via a `?q` query parameter, and the value MUST be [percent-encoded](https://en.wikipedia.org/wiki/Percent-encoding)
   - Suitable for sharing links, sending smaller messages, testing and debugging.
   - DAG-JSON response is the implicit default, unless explicit `Accept` header is passed
-- `POST /reframe`
+- `POST /reframe/{method}`
   - Ephemeral HTTP `POST` request with DAG-JSON or DAG-CBOR message passed in HTTP request body and a mandatory `Content-Type` header informing endpoint how to parse the body
   - Suitable for bigger messages, and when HTTP caching should be skipped for the most fresh results
   - Response type is the same as request, unless explicit `Accept` header is passed


### PR DESCRIPTION
## Context


#### HTTP Caching problems

- single endpoint makes it hard to scale  (have different methods handled by different services)
- Etag generation requires buffering response, effectively breaking streaming 

#### On missing CBOR 

We've b een using Reframe in Kubo for a while and it is clear that Reframe messages are not designed to be created or read by humans.
 
(My subjective opinion) The plaintext  DAG-JSON representation of messages do not really bring  much to the table, because both CIDs and Multiaddrs are in a format that needs manual encoding/decoding anyway, but are still useful during testing ad debugging.

JSON is just bad production format – we are missing CBOR.

####  Why CBOR?

We already support DAG-JSON via a dedicated content type, and our stack uses CBOR in more places than JSON. 

#### Size savings 

Some numbers in https://arxiv.org/abs/2201.03051:

>  ![2022-10-10_20-31](https://user-images.githubusercontent.com/157609/194931532-c8164c73-d1ad-4916-9673-a0053bf36c6a.png)


While companies are free to pay an unnecessary ~20% penalty, we should not create protocols which expect end users to do the same.

## Proposed improvements
 

### (1) Add CBOR format

The improvement proposed here is to add support for requests and responses sent as DAG-CBOR,
with own content type: `application/vnd.ipfs.rpc+dag-cbor`. 

This way Reframe over HTTP would support both DAG-JSON and DAG-CBOR, and it is up to the client to decide what wire format makes sense to them.

### (2) improve HTTP caching

While at it, we've improved the way HTTP caching works, removed the requirement of Etag which caused streaming issues, and added method names to URL paths, to improve scaling / routing on reverse proxies / CDNs.
 
For details, see changes  made to `reframe/REFRAME_HTTP_TRANSPORT.md`

cc @guseggert @petar @willscott 