### PR TITLE
fix: document CBOR in /reframe?q=

### DIFF
--- a/reframe/REFRAME_HTTP_TRANSPORT.md
+++ b/reframe/REFRAME_HTTP_TRANSPORT.md
@@ -32,7 +32,7 @@ All messages sent in HTTP body MUST be encoded as DAG-JSON and use explicit cont
 
 Requests MUST be sent as either:
 
-- `GET /reframe?q={percent-encoded-dag-json}`
+- `GET /reframe?q={percent-encoded-dag-cbor}`
   - DAG-JSON is supported via a `?q` query parameter, and the value MUST be [percent-encoded](https://en.wikipedia.org/wiki/Percent-encoding)
   - Suitable for sharing links, sending smaller messages, testing and debugging.
 - `POST /reframe`


### PR DESCRIPTION
Due to miscommunication, [go-delegated-routing v0.6.0](https://github.com/ipfs/go-delegated-routing)  uses DAG-CBOR  in `?q`  (and not DAG-JSON, like we expected) :see_no_evil: 
Details: https://github.com/ipld/edelweiss/issues/61
 
This PR updates the spec to describe the current pre-alpha implementation.
 
 @guseggert  if we are not planning to surgically fix this (as proposed in https://github.com/ipld/edelweiss/issues/61)  I suggest we update specs to reflect implementation in Kubo 0.16.