### PR TITLE
IPIP-359: Multi gateway client

### DIFF
--- a/integrations/MULTI_GATEWAY_CLIENT.md
+++ b/integrations/MULTI_GATEWAY_CLIENT.md
@@ -1,8 +1,8 @@
-# IPIP 0000: Multi gateway client
+# IPIP-359: Multi gateway client
 
 - Start Date: 2022-12-16
 - Related Issues:
-  - None
+  - https://github.com/ipfs/specs/pull/359
 - Relies on specs:
   - IPIP-0280
 


### PR DESCRIPTION
A spec to describe how multi gateway clients - formally known as racing gateways - should behave. This is very much a companion spec to https://github.com/ipfs/specs/pull/356.

To refine it's place.
This spec describes how multi gateway clients work and should be implemented.
https://github.com/ipfs/specs/pull/356 would have this in it's implementation.