### PR TITLE
Document suggested IPNS Entry TTL default

### DIFF
--- a/src/ipns/ipns-record.md
+++ b/src/ipns/ipns-record.md
@@ -151,10 +151,9 @@ A logical :dfn[IPNS Record] is a data structure containing the following fields:
   - Implementations MUST include this value in inside the DAG-CBOR document at `IpnsEntry.data[Sequence]`.
 
 - **TTL** (uint64)
-  - A hint for how long (in nanoseconds) the record should be cached before going back to, for instance the DHT, in order to check if it has been updated.
+  - A hint for how long (in nanoseconds) the record should be cached before going back to, for instance the DHT, in order to check if it has been updated. The function and trade-offs of this value are analogous to the TTL of DNS record.
   - Implementations MUST include this value inside the DAG-CBOR document at `IpnsEntry.data[TTL]`.
   - Suggested default: 1 hour (3 600 000 000 000 nanoseconds).
-
 
 - **Public Key** (bytes)
   - Public key used to sign this record.

--- a/src/ipns/ipns-record.md
+++ b/src/ipns/ipns-record.md
@@ -3,7 +3,7 @@ title: IPNS Record and Protocol
 description: >
   Specifies the IPNS protocol in a language-agnostic manner, allowing everyone to
   create a compatible IPNS Record Publisher or Resolver.
-date: 2023-07-24
+date: 2023-10-03
 maturity: reliable
 editors:
   - name: Vasco Santos
@@ -151,8 +151,10 @@ A logical :dfn[IPNS Record] is a data structure containing the following fields:
   - Implementations MUST include this value in inside the DAG-CBOR document at `IpnsEntry.data[Sequence]`.
 
 - **TTL** (uint64)
-  - A hint for how long the record should be cached before going back to, for instance the DHT, in order to check if it has been updated.
+  - A hint for how long (in nanoseconds) the record should be cached before going back to, for instance the DHT, in order to check if it has been updated.
   - Implementations MUST include this value inside the DAG-CBOR document at `IpnsEntry.data[TTL]`.
+  - Suggested default: 1 hour (3 600 000 000 000 nanoseconds).
+
 
 - **Public Key** (bytes)
   - Public key used to sign this record.


### PR DESCRIPTION
Initial context: https://github.com/ipfs/interface-go-ipfs-core/pull/94#discussion_r1085244474.

Currently, the default IPNS Entry TTL is hard coded to 1 minute. 1 minute is a very short duration for TTL. For DNS, 12 and 24 hours are very common TTL values. If we have a low value from the start, there is barely any performance improvement by setting a TTL manually, since no one is going to manually set it for a larger value.

With this PR, we would like to add a suggested default of 12 hours. If the user (publisher of the website), requires more frequent updates, they can always use the `--ttl` flag in `ipns name publish` to override the default.