### PR TITLE
fix: keep architecture listing in sync

### DIFF
--- a/src/_includes/specs/architecture.html
+++ b/src/_includes/specs/architecture.html
@@ -1,0 +1,8 @@
+<dl>
+  <dt><a href="/architecture/principles/">IPFS Principles</a></dt>
+  <dd>
+    IPFS is a suite of specifications and tools that are defined by two key characteristics: content-addressing and
+    transport-agnosticity. This document provides context and details about these characteristics. In doing so it defines what
+    is or is not an IPFS implementation.
+  </dd>
+</dl>

--- a/src/architecture/index.html
+++ b/src/architecture/index.html
@@ -8,14 +8,7 @@ description: |
 {% include 'header.html' %}
 
 <main>
-  <dl>
-    <dt><a href="/architecture/principles/">IPFS Principles</a></dt>
-    <dd>
-      IPFS is a suite of specifications and tools that are defined by two key characteristics: content-addressing and
-      transport-agnosticity. This document provides context and details about these characteristics. In doing so it defines what
-      is or is not an IPFS implementation.
-    </dd>
-  </dl>
+  {% include 'specs/architecture.html' %}
 </main>
 
 {% include 'footer.html' %}

--- a/src/index.html
+++ b/src/index.html
@@ -84,14 +84,7 @@ title: Home
           These documents define the architectural principles that IPFS is built upon, and can be used as tools to evaluate
           implementations and applications of IPFS.
         </p>
-        <dl>
-          <dt><a href="/architecture/principles/">IPFS Principles</a></dt>
-          <dd>
-            IPFS is a suite of specifications and tools that are defined by two key characteristics: content-addressing and
-            transport-agnosticity. This document provides context and details about these characteristics. In doing so it defines what
-            is or is not an IPFS implementation.
-          </dd>
-        </dl>
+        {% include 'specs/architecture.html' %}
       </section>
       <section>
         <h3><a href="/meta/">Meta</a></h3>


### PR DESCRIPTION
I'll merge this if CI passes. This is a minor fix and should've been done in the PR where this was added.