### PR TITLE
Put architecture/meta up top

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -63,22 +63,6 @@ title: Home
     </p>
     <div class="basic-grid">
       <section>
-        <h3><a href="/http-gateways/">HTTP Gateways</a></h3>
-        <p>
-          IPFS Gateway acts as a bridge between traditional HTTP clients and IPFS. Through the gateway, users can download files,
-          directories and other IPLD data stored in IPFS as if they were stored in a traditional web server.
-        </p>
-        {% include 'specs/http-gateways/http.html' %}
-        {% include 'specs/http-gateways/web.html' %}
-      </section>
-      <section>
-        <h3><a href="/ipns/">InterPlanetary Naming System</a></h3>
-        <p>
-          The InterPlanetary Naming System (IPNS) is a naming system responsible for creating, reading and updating mutable pointers to data.
-        </p>
-        {% include 'specs/ipns.html' %}
-      </section>
-      <section>
         <h3><a href="/architecture/">Architecture</a></h3>
         <p>
           These documents define the architectural principles that IPFS is built upon, and can be used as tools to evaluate
@@ -94,6 +78,22 @@ title: Home
           etc.
         </p>
         {% include 'specs/meta.html' %}
+      </section>
+      <section>
+        <h3><a href="/http-gateways/">HTTP Gateways</a></h3>
+        <p>
+          IPFS Gateway acts as a bridge between traditional HTTP clients and IPFS. Through the gateway, users can download files,
+          directories and other IPLD data stored in IPFS as if they were stored in a traditional web server.
+        </p>
+        {% include 'specs/http-gateways/http.html' %}
+        {% include 'specs/http-gateways/web.html' %}
+      </section>
+      <section>
+        <h3><a href="/ipns/">InterPlanetary Naming System</a></h3>
+        <p>
+          The InterPlanetary Naming System (IPNS) is a naming system responsible for creating, reading and updating mutable pointers to data.
+        </p>
+        {% include 'specs/ipns.html' %}
       </section>
     </div>
   </section>


### PR DESCRIPTION
I did this because it seems a bit odd to have underlying elements like architecture and meta at the bottom even though they are foundational for the specs that follow.

This was flagged to me in a side comment by @momack2 .  