### PR TITLE
feat: bump spec-generator version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SPEC_GENERATOR_VER=v1.3.1
+SPEC_GENERATOR_VER=v1.3.2
 
 all: website
 


### PR DESCRIPTION
Fixes a small bug I inadvertently added to the spec-generator: when the spec would start with a title, it would be considered part of the abstract. This affected IPIPs. It is now fixed.