### PR TITLE
style: 'free to' → SHOULD/MAY

### DIFF
--- a/src/http-gateways/dnslink-gateway.md
+++ b/src/http-gateways/dnslink-gateway.md
@@ -92,5 +92,5 @@ Same as "HTTP Response" of :cite[path-gateway].
 
 ## Redirects, single-page applications, and custom 404s
 
-DNSLink Gateway implementations are free to include `_redirects` file support
+DNSLink Gateway implementations SHOULD include `_redirects` file support
 defined in :cite[web-redirects-file].

--- a/src/http-gateways/path-gateway.md
+++ b/src/http-gateways/path-gateway.md
@@ -53,7 +53,7 @@ Downloads data at specified **immutable** content path.
 
 Same as GET, but does not return any payload.
 
-Implementations are free to limit the scope of IPFS data transfer triggered by
+Implementations SHOULD limit the scope of IPFS data transfer triggered by
 `HEAD` requests to a minimal DAG subset required for producing response headers
 such as
 [`X-Ipfs-Roots`](#x-ipfs-roots-response-header),
@@ -120,7 +120,7 @@ fetch, a [`412 Precondition Failed`](#412-precondition-failed) HTTP status code
 should be returned by the gateway without any payload or specific HTTP headers.
 
 NOTE: when processing a request for a DAG, traversing it and checking every CID
-might be too expensive. Implementations are free to implement own heuristics to
+might be too expensive. Implementations SHOULD implement own heuristics to
 maximize cache hits while minimizing performance cost of checking if the entire
 DAG is locally cached. A good rule of thumb is to at the minimum test if the root
 block is in the local cache.
@@ -354,10 +354,10 @@ Returned directive depends on requested content path and format:
   resources under `/ipns/{id-with-ttl}/` namespace; `max-age=<ttl>` should
   indicate remaining TTL of the mutable pointer such as IPNS record or DNSLink
   TXT record.
-  - Implementations are free to place an upper bound on any TTL received, as
-    noted in Section 8 of :cite[rfc2131].
-  - If TTL value is unknown, implementations are free to set it to a static
-    value, but it should not be lower than 60 seconds.
+  - Implementations MAY place an upper bound on any TTL received, as
+    noted in Section 8 of :cite[rfc2181].
+  - If TTL value is unknown, implementations SHOULD set it to a static
+    value, but it SHOULD not be lower than 60 seconds.
 
 ### `Last-Modified` (response header)
 
@@ -389,9 +389,10 @@ Returned with custom response formats such as `application/vnd.ipld.car` or
 `application/vnd.ipld.raw`. CAR must be returned with explicit version.
 Example: `Content-Type: application/vnd.ipld.car; version=1`
 
-When no explicit response format is provided with the request, and the
+When deserialized responses are enabled,
+and no explicit response format is provided with the request, and the
 requested data itself has no built-in content type metadata, implementations
-are free to perform content type sniffing based on file name
+SHOULD perform content type sniffing based on file name
 (from :ref[url] path, or optional [`filename`](#filename-request-query-parameter) parameter)
 and magic bytes to improve the utility of produced responses.
 
@@ -538,12 +539,27 @@ Optional, present in certain response types:
   non-executable binary response types are not used in `<script>` and `<style>`
   HTML tags.
 
-### `X-Trace-Id` (response header)
+### `Server-Timing` (response header)
 
-Optional. Implementations are free to use this header to return a globally
+Optional. Implementations MAY use this header to communicate one or more
+metrics and descriptions for the given request-response cycle.
+
+See `Server-Timing` at [W3C: Server Timing](https://www.w3.org/TR/server-timing/#the-server-timing-header-field).
+
+### `Traceparent` (response header)
+
+Optional. Implementations MAY use this header to return a globally
 unique identifier to help in debugging errors and performance issues.
 
-A good practice is to always return it with HTTP error [status codes](#response-status-codes) >=`400`.
+See `Traceparent` at [W3C: Trace Context](https://www.w3.org/TR/trace-context-1/#traceparent-header).
+
+### `Tracestate` (response header)
+
+Optional. Implementations MAY use this header to return a additional
+vendor-specific trace identification information across different distributed
+tracing systems and is a companion header for the `Traceparent` header.
+
+See `Tracestate` at [W3C: Trace Context](https://www.w3.org/TR/trace-context-1/#tracestate-header).
 
 ## Response Payload
 
@@ -669,7 +685,7 @@ Gateway MUST respond with HTTP error when requested CID is on any of active deny
 - [410 Gone](#410-gone) returned when CID is denied for non-legal reasons, or when the exact reason is unknown
 - [451 Unavailable For Legal Reasons](#451-unavailable-for-legal-reasons) returned when denylist indicates that content was blocked on legal basis
 
-Implementation is free to apply some denylists by default as long the gateway
+Gateway implementation MAY apply some denylists by default as long the gateway
 operator is able to inspect and modify the list of denylists that are applied.
 
 **Examples of public deny lists**
@@ -681,7 +697,7 @@ operator is able to inspect and modify the list of denylists that are applied.
 
 ## Generated HTML with directory index
 
-While implementations are free to decide on the way HTML directory listing is
+While implementations decide on the way HTML directory listing is
 generated and presented to the user, following below suggestions is advised.
 
 Linking to alternative response types such as CAR and dag-json allows clients

--- a/src/http-gateways/subdomain-gateway.md
+++ b/src/http-gateways/subdomain-gateway.md
@@ -257,5 +257,5 @@ From there, regular subdomain gateway logic applies.
 
 ## Redirects, single-page applications, and custom 404s
 
-Subdomain Gateway implementations are free to include `_redirects` file
+Subdomain Gateway implementations SHOULD include `_redirects` file
 support defined in :cite[web-redirects-file].

--- a/src/http-gateways/trustless-gateway.md
+++ b/src/http-gateways/trustless-gateway.md
@@ -57,14 +57,15 @@ Same as in :cite[path-gateway], but with limited number of supported response ty
 
 This HTTP header is required when running in a strict, trustless mode.
 
-Gateway is free to return HTTP 400 Bad Request when running in strict trustless
-mode and  `Accept` header is missing
-
 Below response types MUST to be supported:
-
 - [application/vnd.ipld.raw](https://www.iana.org/assignments/media-types/application/vnd.ipld.raw) – requests a single, verifiable raw block to be returned
+
+Below response types SHOULD to be supported:
 - [application/vnd.ipld.car](https://www.iana.org/assignments/media-types/application/vnd.ipld.car) – disables IPLD/IPFS deserialization, requests a verifiable CAR stream to be returned
 - [application/vnd.ipfs.ipns-record](https://www.iana.org/assignments/media-types/application/vnd.ipfs.ipns-record) – requests a verifiable :cite[ipns-record] (multicodec `0x0300`).
+
+Gateway SHOULD return HTTP 400 Bad Request when running in strict trustless
+mode (no deserialized responses) and  `Accept` header is missing.
 
 # HTTP Response
 

--- a/src/http-gateways/web-redirects-file.md
+++ b/src/http-gateways/web-redirects-file.md
@@ -140,7 +140,7 @@ The [max file size](#max-file-size) helps to prevent an additional [denial of se
 ## Test fixtures
 
 Sample files for various test cases can be found in `QmQyqMY5vUBSbSxyitJqthgwZunCQjDVtNd8ggVCxzuPQ4`.
-Implementations are free to use it for internal testing.
+Implementations SHOULD use it for internal testing.
 
 ```
 $ ipfs ls QmQyqMY5vUBSbSxyitJqthgwZunCQjDVtNd8ggVCxzuPQ4

--- a/src/ipns/ipns-record.md
+++ b/src/ipns/ipns-record.md
@@ -144,7 +144,7 @@ A logical :dfn[IPNS Record] is a data structure containing the following fields:
 - **Extensible Data** (DAG-CBOR)
   - Extensible record data in [DAG-CBOR](https://ipld.io/specs/codecs/dag-cbor/spec/) format.
   - The default set of fields can be augmented with additional information.
-    - Implementations are free to leverage this, or simply ignore unexpected fields.
+    - Implementations MAY leverage this, but otherwise MUST ignore unexpected fields.
     - A good practice is to:
       - prefix custom field names with `_` to avoid collisions with any new
         mandatory fields that may be added in a future version of this


### PR DESCRIPTION
This editorial PR: replaces ambiguous 'free to' with SHOULD/MAY
