### PR TITLE
IPIP-428: Allowing V2-Only Records in IPNS

### DIFF
--- a/src/ipips/ipip-0428.md
+++ b/src/ipips/ipip-0428.md
@@ -159,6 +159,8 @@ TODO: IPNS record that is valid for 100 years and
 1. V1+V2 (only signatureV2 valid) → record valid
 1. V2-only (no V1 fields) → record valid
 
+Tracked in: <https://github.com/ipfs/gateway-conformance/issues/144>
+
 ### Copyright
 
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/src/ipips/ipip-0428.md
+++ b/src/ipips/ipip-0428.md
@@ -56,10 +56,10 @@ V2-only IPNS records and ensure clients will interpret them as valid IPNS.
 
 Finish V2 story by making V2-Only records possible, namely:
 
-- creation: document and default to lean V2-Only records, keep V1+V2 as legacy
-  backward-compatible variant
+- Record Creation: document and default to lean V2-Only records, keep V1+V2 as legacy
+  backward-compatible variant.
 
-- validation: adjust the algorithm to stop requiring V1 fields when there is no
+- Record Validation: adjust the algorithm to stop requiring V1 fields when there is no
   `signatureV1`.
 
 For details, see the updated :cite[ipns-record] specification.
@@ -67,7 +67,7 @@ For details, see the updated :cite[ipns-record] specification.
 ## Design rationale
 
 For modern IPNS, the outer `IpnsEntry` protobuf should effectively only have
-two required fields:  `data` and its `signatureV2`, and such record, as long
+two required fields: `data` and its `signatureV2`, and such record, as long
 signature is valid, should be accepted as valid.
 
 At the same time, we don't want to break existig software, especially software
@@ -90,17 +90,17 @@ We can get to that future in two steps:
    swarm supports V2-Only records, libraries like go-ipns/js-ipfs and
    implementations like Kubo stop producing V1+V2 and switch to publishing
    V2-only records that are protobuf with only two fields: Data
-   CBOR+signatureV2
+   CBOR+signatureV2.
 
 
 ### User benefit
 
-- End users: the main benefit for end user is smaller size of IPNS record and
-  less complex creation/validation of modern V2-only records.
+- End users: the main benefit for end user is the smaller size of IPNS Records and
+  less complexity during creation/validation of modern V2-only records.
 
 - Developers interested in IPNS: by making IPNS Record creation as simple as
   "create DAG-CBOR with these fields, and sign it", and validation to
-  "signatureV2 should match the DAG-CBOR value and key". we've removed surface
+  "signatureV2 should match the DAG-CBOR value and key". We've removed surface
   for bugs, making it easier to reason about for use in greenfield projects.
 
 - IPFS ecosystem: lowering the complexity related to IPNS record creation and

--- a/src/ipips/ipip-0428.md
+++ b/src/ipips/ipip-0428.md
@@ -17,6 +17,9 @@ editors:
         url: https://protocol.ai/
 relatedIssues:
   - https://github.com/ipfs/specs/issues/376
+  - https://github.com/ipfs/boxo/pull/339
+  - https://github.com/ipfs/kubo/pull/9932
+  - https://github.com/ipfs/js-ipns/pull/234
 order: 428
 tags: ['ipips']
 ---
@@ -92,7 +95,6 @@ We can get to that future in two steps:
    V2-only records that are protobuf with only two fields: Data
    CBOR+signatureV2.
 
-
 ### User benefit
 
 - End users: the main benefit for end user is the smaller size of IPNS Records and
@@ -133,19 +135,18 @@ included at the end of this IPIP.
 Describe alternate designs that were considered and related work.
 
 1. Just switch to V2-only as the new default!
-
-  - No, this would be a breaking change. We have to do this in two steps,
-    because we've rushed the way V2 was introduced in 2021, and STILL require
-    field copying, even when `signatureV1` is missing. So technically there was
-    never "V2", it was more like "V1.5". Only with this IPIP, we finally
-    adjust validation to only care about CBOR values when there is no `signatureV1`.
+   - No, this would be a breaking change. We have to do this in two steps,
+     because we've rushed the way V2 was introduced in 2021, and STILL require
+     field copying, even when `signatureV1` is missing. So technically there
+     was never "V2", it was more like "V1.5". Only with this IPIP, we finally
+     adjust validation to only care about CBOR values when there is no
+     `signatureV1`.
 
 2. Why keeping the outer protobuf envelope? Could we make IPNS DAG-CBOR-only?
-
    - Due to how long it takes for decentralized network nodes to upgrade, we prefer evolution rather than revolution.
-   - Protobuf is an useful envelope for two reasons:
-     1. ensures the opaque V2-only record can be passed and stored in existing infrastructure
-     2. allows us to evolve IPNS record ("V3") in the future without impacting existing infrastructure
+   - Protobuf is a useful envelope for two reasons:
+     1. Ensures the opaque V2-only record can be passed and stored in existing infrastructure.
+     2. Allows us to evolve IPNS record ("V3") in the future without impacting existing infrastructure.
 
 ## Test fixtures
 
@@ -153,10 +154,10 @@ TODO: IPNS record that is valid for 100 years and
 
 1. V1-only → record invalid
 1. V1+V2 (both signatures valid) → record valid
-1. V1+V2 (both signatures valid, but 'value' is different in V1) → record invalid
-1. V1+V2 (only V1 valid) → record invalid
-1. V1+V2 (only V2 valid, V1 missing signature) → record valid (because we do V1 validation only when signatureV1 is present in protobuf)
-1. V2-only (only V2 valid) → record valid
+1. V1+V2 (both signatures valid, but 'value' is different in V1 pb) → record invalid
+1. V1+V2 (only signatureV1 valid) → record invalid
+1. V1+V2 (only signatureV2 valid) → record valid
+1. V2-only (no V1 fields) → record valid
 
 ### Copyright
 

--- a/src/ipips/ipip-0428.md
+++ b/src/ipips/ipip-0428.md
@@ -1,7 +1,7 @@
 ---
 title: "IPIP-0428: Allowing V2-Only Records in IPNS"
 date: 2023-07-24
-ipip: proposal
+ipip: ratified
 editors:
   - name: Marcin Rataj
     github: lidel
@@ -35,14 +35,14 @@ decisions made in 2021.
 
 The "V1+V2" record creation and validation was reverse-engineered and documented
 the current state in [ipfs/specs#319](https://github.com/ipfs/specs/pull/319),
-and created a base for specifications to improve upon.
+which created a base for specifications to improve upon.
 
 A quick refresher on how IPNS Record lifecycle works today (2023 Q2):
 
-- Record Creation produces both V1 and V2 signatures, and the record has
+- _Record Creation_ produces both V1 and V2 signatures, and the record has
   duplicated values in both top level protobuf AND `data` CBOR field.
 
-- Record Validation only cares about V2 signature, but still requires fields
+- _Record Validation_ only cares about V2 signature, but still requires fields
   related to V1 to be always present in a record and match values from CBOR in
   `data` field, for the record to be considered valid.
 
@@ -78,9 +78,10 @@ and hardware devices which use IPNS for pulling updates.
 
 We can get to that future in two steps:
 
-1. Reference implementations (go-ipfs, js-ipfs) will keep producing V1+V2
+1. Reference implementations (boxo/ipns, js-ipns) will keep producing V1+V2
    records as backward-compatible default, but we adjust validation algorithm
-   to allow V2-only records, and support creation of such records as opt-in.
+   to allow V2-only records, and support creation of such records as opt-in in
+   modern implementations of IPFS+IPNS, like Kubo (GO) and Helia (JS).
    - Namely, only check/require fields to be duplicated in top level protobuf IF
      `signatureV1` is present in the `IpnsEntry` protobuf.
      - IF there is no `signatureV1`, the V1 record would be invalid anyway.
@@ -90,8 +91,8 @@ We can get to that future in two steps:
           are considered valid.
 
 2. At some point in the future, e.g. when we see the majority of the public
-   swarm supports V2-Only records, libraries like go-ipns/js-ipfs and
-   implementations like Kubo stop producing V1+V2 and switch to publishing
+   swarm supports V2-Only records, libraries like boxo/ipns, js-ipns and
+   implementations like Kubo will stop producing V1+V2 and switch to publishing
    V2-only records that are protobuf with only two fields: Data
    CBOR+signatureV2.
 
@@ -150,16 +151,25 @@ Describe alternate designs that were considered and related work.
 
 ## Test fixtures
 
-TODO: IPNS record that is valid for 100 years and
+To make testing easier below are test vectors in form of IPNS records along
+with the expected verification results. These test records are valid for 100
+years, making them safe for use in CI tests.
 
-1. V1-only → record invalid
-1. V1+V2 (both signatures valid) → record valid
-1. V1+V2 (both signatures valid, but 'value' is different in V1 pb) → record invalid
-1. V1+V2 (only signatureV1 valid) → record invalid
-1. V1+V2 (only signatureV2 valid) → record valid
-1. V2-only (no V1 fields) → record valid
+1. [V1-only](https://github.com/ipfs/gateway-conformance/raw/9444cca76ef362904f1ce7a9c6d553c53da5feb3/fixtures/ipns_records/k51qzi5uqu5dm4tm0wt8srkg9h9suud4wuiwjimndrkydqm81cqtlb5ak6p7ku_v1.ipns-record) → record invalid
+1. [V1+V2](https://github.com/ipfs/gateway-conformance/raw/9444cca76ef362904f1ce7a9c6d553c53da5feb3/fixtures/ipns_records/k51qzi5uqu5dlkw8pxuw9qmqayfdeh4kfebhmreauqdc6a7c3y7d5i9fi8mk9w_v1-v2.ipns-record) (both signatures valid) → record valid, value points at `/ipfs/bafkqaddwgevxmmraojswg33smq`
+1. [V1+V2](https://github.com/ipfs/gateway-conformance/raw/9444cca76ef362904f1ce7a9c6d553c53da5feb3/fixtures/ipns_records/k51qzi5uqu5dlmit2tuwdvnx4sbnyqgmvbxftl0eo3f33wwtb9gr7yozae9kpw_v1-v2-broken-v1-value.ipns-record) (both signatures valid, but 'value' is different in V1 pb vs V2 CBOR) → record invalid
+1. [V1+V2](https://github.com/ipfs/gateway-conformance/raw/9444cca76ef362904f1ce7a9c6d553c53da5feb3/fixtures/ipns_records/k51qzi5uqu5diamp7qnnvs1p1gzmku3eijkeijs3418j23j077zrkok63xdm8c_v1-v2-broken-signature-v2.ipns-record) (only signatureV1 valid) → record invalid
+1. [V1+V2](https://github.com/ipfs/gateway-conformance/raw/9444cca76ef362904f1ce7a9c6d553c53da5feb3/fixtures/ipns_records/k51qzi5uqu5dilgf7gorsh9vcqqq4myo6jd4zmqkuy9pxyxi5fua3uf7axph4y_v1-v2-broken-signature-v1.ipns-record) (only signatureV2 valid) → record valid, value points at `/ipfs/bafkqahtwgevxmmrao5uxi2bamjzg623fnyqhg2lhnzqxi5lsmuqhmmi`
+1. [V2-only](https://github.com/ipfs/gateway-conformance/raw/9444cca76ef362904f1ce7a9c6d553c53da5feb3/fixtures/ipns_records/k51qzi5uqu5dit2ku9mutlfgwyz8u730on38kd10m97m36bjt66my99hb6103f_v2.ipns-record) (no V1 fields) → record valid
 
-Tracked in: <https://github.com/ipfs/gateway-conformance/issues/144>
+:::note
+
+Implementers can either write own tests against the above test vectors, or run
+[gateway-conformance](https://github.com/ipfs/gateway-conformance/) test suite,
+which includes tests for these vectors since
+[gateway-conformance/pull/157](https://github.com/ipfs/gateway-conformance/pull/157).
+
+:::
 
 ### Copyright
 

--- a/src/ipips/ipip-0428.md
+++ b/src/ipips/ipip-0428.md
@@ -1,0 +1,163 @@
+---
+title: "IPIP-0428: Allowing V2-Only Records in IPNS"
+date: 2023-07-24
+ipip: proposal
+editors:
+  - name: Marcin Rataj
+    github: lidel
+    url: https://lidel.org/
+    affiliation:
+        name: Protocol Labs
+        url: https://protocol.ai/
+  - name: Henrique Dias
+    github: hacdias
+    url: https://hacdias.com/
+    affiliation:
+        name: Protocol Labs
+        url: https://protocol.ai/
+relatedIssues:
+  - https://github.com/ipfs/specs/issues/376
+order: 428
+tags: ['ipips']
+---
+
+## Summary
+
+Introduce support for creation and validation of compact, V2-only IPNS Records.
+
+## Motivation
+
+IPNS record creation and validation is overly complex due to the legacy of
+decisions made in 2021.
+
+The "V1+V2" record creation and validation was reverse-engineered and documented
+the current state in [ipfs/specs#319](https://github.com/ipfs/specs/pull/319),
+and created a base for specifications to improve upon.
+
+A quick refresher on how IPNS Record lifecycle works today (2023 Q2):
+
+- Record Creation produces both V1 and V2 signatures, and the record has
+  duplicated values in both top level protobuf AND `data` CBOR field.
+
+- Record Validation only cares about V2 signature, but still requires fields
+  related to V1 to be always present in a record and match values from CBOR in
+  `data` field, for the record to be considered valid.
+
+We've been producing and expecting these hybrid V1+V2 records [since 2021](https://github.com/ipfs/js-ipns/pull/121).
+
+An unfortunate result is that all mandatory values MUST be duplicated, even
+when both ends use a modern client that only cares about `signatureV2` that
+guards CBOR field, otherwise the record will not be valid.
+
+What this IPIP aims to improve is allow implementations to produce lean,
+V2-only IPNS records and ensure clients will interpret them as valid IPNS.
+
+## Detailed design
+
+Finish V2 story by making V2-Only records possible, namely:
+
+- creation: document and default to lean V2-Only records, keep V1+V2 as legacy
+  backward-compatible variant
+
+- validation: adjust the algorithm to stop requiring V1 fields when there is no
+  `signatureV1`.
+
+For details, see the updated :cite[ipns-record] specification.
+
+## Design rationale
+
+For modern IPNS, the outer `IpnsEntry` protobuf should effectively only have
+two required fields:  `data` and its `signatureV2`, and such record, as long
+signature is valid, should be accepted as valid.
+
+At the same time, we don't want to break existig software, especially software
+and hardware devices which use IPNS for pulling updates.
+
+We can get to that future in two steps:
+
+1. Reference implementations (go-ipfs, js-ipfs) will keep producing V1+V2
+   records as backward-compatible default, but we adjust validation algorithm
+   to allow V2-only records, and support creation of such records as opt-in.
+   - Namely, only check/require fields to be duplicated in top level protobuf IF
+     `signatureV1` is present in the `IpnsEntry` protobuf.
+     - IF there is no `signatureV1`, the V1 record would be invalid anyway.
+     - IF there is no `signatureV1` but `signatureV2` and `data` fields
+       are present and valid, the V2-only record should be considered valid.
+        - This will allow people to build V2-only systems that produce records that
+          are considered valid.
+
+2. At some point in the future, e.g. when we see the majority of the public
+   swarm supports V2-Only records, libraries like go-ipns/js-ipfs and
+   implementations like Kubo stop producing V1+V2 and switch to publishing
+   V2-only records that are protobuf with only two fields: Data
+   CBOR+signatureV2
+
+
+### User benefit
+
+- End users: the main benefit for end user is smaller size of IPNS record and
+  less complex creation/validation of modern V2-only records.
+
+- Developers interested in IPNS: by making IPNS Record creation as simple as
+  "create DAG-CBOR with these fields, and sign it", and validation to
+  "signatureV2 should match the DAG-CBOR value and key". we've removed surface
+  for bugs, making it easier to reason about for use in greenfield projects.
+
+- IPFS ecosystem: lowering the complexity related to IPNS record creation and
+  validation makes it more likely for third-party interoperable IPNS
+  implementations to happen.
+
+### Compatibility
+
+- This is backward-compatible, we adjust validation logic to allow V2-only
+  records, but all V1+V2 records that are being used in the wild today are
+  still valid
+
+- V2-only rollout is not part of this IPIP.
+  - Our suggestion is to default to creating V1+V2 records for now, keeping
+    backward-compatibility with the old IPNS clients.
+
+  - Creation of V2-only records should be introduced as an explicit opt-in. It
+    is up to implementations to decide when it is feasible to default to
+    creating V2-only records on IPNS publish.
+
+### Security
+
+- `IpnsEntry.signatureV1` (protobuf field) is parsed only by legacy clients, modern ones ignore this value
+
+It is highly advised to implement validation conformance tests using the fixtures
+included at the end of this IPIP.
+
+### Alternatives
+
+Describe alternate designs that were considered and related work.
+
+1. Just switch to V2-only as the new default!
+
+  - No, this would be a breaking change. We have to do this in two steps,
+    because we've rushed the way V2 was introduced in 2021, and STILL require
+    field copying, even when `signatureV1` is missing. So technically there was
+    never "V2", it was more like "V1.5". Only with this IPIP, we finally
+    adjust validation to only care about CBOR values when there is no `signatureV1`.
+
+2. Why keeping the outer protobuf envelope? Could we make IPNS DAG-CBOR-only?
+
+   - Due to how long it takes for decentralized network nodes to upgrade, we prefer evolution rather than revolution.
+   - Protobuf is an useful envelope for two reasons:
+     1. ensures the opaque V2-only record can be passed and stored in existing infrastructure
+     2. allows us to evolve IPNS record ("V3") in the future without impacting existing infrastructure
+
+## Test fixtures
+
+TODO: IPNS record that is valid for 100 years and
+
+1. V1-only → record invalid
+1. V1+V2 (both signatures valid) → record valid
+1. V1+V2 (both signatures valid, but 'value' is different in V1) → record invalid
+1. V1+V2 (only V1 valid) → record invalid
+1. V1+V2 (only V2 valid, V1 missing signature) → record valid (because we do V1 validation only when signatureV1 is present in protobuf)
+1. V2-only (only V2 valid) → record valid
+
+### Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/src/ipips/ipip-0428.md
+++ b/src/ipips/ipip-0428.md
@@ -155,12 +155,12 @@ To make testing easier below are test vectors in form of IPNS records along
 with the expected verification results. These test records are valid for 100
 years, making them safe for use in CI tests.
 
-1. [V1-only](https://github.com/ipfs/gateway-conformance/raw/9444cca76ef362904f1ce7a9c6d553c53da5feb3/fixtures/ipns_records/k51qzi5uqu5dm4tm0wt8srkg9h9suud4wuiwjimndrkydqm81cqtlb5ak6p7ku_v1.ipns-record) → record invalid
-1. [V1+V2](https://github.com/ipfs/gateway-conformance/raw/9444cca76ef362904f1ce7a9c6d553c53da5feb3/fixtures/ipns_records/k51qzi5uqu5dlkw8pxuw9qmqayfdeh4kfebhmreauqdc6a7c3y7d5i9fi8mk9w_v1-v2.ipns-record) (both signatures valid) → record valid, value points at `/ipfs/bafkqaddwgevxmmraojswg33smq`
-1. [V1+V2](https://github.com/ipfs/gateway-conformance/raw/9444cca76ef362904f1ce7a9c6d553c53da5feb3/fixtures/ipns_records/k51qzi5uqu5dlmit2tuwdvnx4sbnyqgmvbxftl0eo3f33wwtb9gr7yozae9kpw_v1-v2-broken-v1-value.ipns-record) (both signatures valid, but 'value' is different in V1 pb vs V2 CBOR) → record invalid
-1. [V1+V2](https://github.com/ipfs/gateway-conformance/raw/9444cca76ef362904f1ce7a9c6d553c53da5feb3/fixtures/ipns_records/k51qzi5uqu5diamp7qnnvs1p1gzmku3eijkeijs3418j23j077zrkok63xdm8c_v1-v2-broken-signature-v2.ipns-record) (only signatureV1 valid) → record invalid
-1. [V1+V2](https://github.com/ipfs/gateway-conformance/raw/9444cca76ef362904f1ce7a9c6d553c53da5feb3/fixtures/ipns_records/k51qzi5uqu5dilgf7gorsh9vcqqq4myo6jd4zmqkuy9pxyxi5fua3uf7axph4y_v1-v2-broken-signature-v1.ipns-record) (only signatureV2 valid) → record valid, value points at `/ipfs/bafkqahtwgevxmmrao5uxi2bamjzg623fnyqhg2lhnzqxi5lsmuqhmmi`
-1. [V2-only](https://github.com/ipfs/gateway-conformance/raw/9444cca76ef362904f1ce7a9c6d553c53da5feb3/fixtures/ipns_records/k51qzi5uqu5dit2ku9mutlfgwyz8u730on38kd10m97m36bjt66my99hb6103f_v2.ipns-record) (no V1 fields) → record valid
+1. [V1-only](https://dweb.link/ipfs/bafybeifkipmlz2fehxda6y7x752uolfed7bdd46jzdammpfga5zrnkq33u/k51qzi5uqu5dm4tm0wt8srkg9h9suud4wuiwjimndrkydqm81cqtlb5ak6p7ku_v1.ipns-record) → record invalid
+2. [V1+V2](https://dweb.link/ipfs/bafybeifkipmlz2fehxda6y7x752uolfed7bdd46jzdammpfga5zrnkq33u/k51qzi5uqu5dlkw8pxuw9qmqayfdeh4kfebhmreauqdc6a7c3y7d5i9fi8mk9w_v1-v2.ipns-record) (both signatures valid) → record valid, value points at `/ipfs/bafkqaddwgevxmmraojswg33smq`
+3. [V1+V2](https://dweb.link/ipfs/bafybeifkipmlz2fehxda6y7x752uolfed7bdd46jzdammpfga5zrnkq33u/k51qzi5uqu5dlmit2tuwdvnx4sbnyqgmvbxftl0eo3f33wwtb9gr7yozae9kpw_v1-v2-broken-v1-value.ipns-record) (both signatures valid, but 'value' is different in V1 pb vs V2 CBOR) → record invalid
+4. [V1+V2](https://dweb.link/ipfs/bafybeifkipmlz2fehxda6y7x752uolfed7bdd46jzdammpfga5zrnkq33u/k51qzi5uqu5diamp7qnnvs1p1gzmku3eijkeijs3418j23j077zrkok63xdm8c_v1-v2-broken-signature-v2.ipns-record) (only signatureV1 valid) → record invalid
+5. [V1+V2](https://dweb.link/ipfs/bafybeifkipmlz2fehxda6y7x752uolfed7bdd46jzdammpfga5zrnkq33u/k51qzi5uqu5dilgf7gorsh9vcqqq4myo6jd4zmqkuy9pxyxi5fua3uf7axph4y_v1-v2-broken-signature-v1.ipns-record) (only signatureV2 valid) → record valid, value points at `/ipfs/bafkqahtwgevxmmrao5uxi2bamjzg623fnyqhg2lhnzqxi5lsmuqhmmi`
+6. [V2-only](https://dweb.link/ipfs/bafybeifkipmlz2fehxda6y7x752uolfed7bdd46jzdammpfga5zrnkq33u/k51qzi5uqu5dit2ku9mutlfgwyz8u730on38kd10m97m36bjt66my99hb6103f_v2.ipns-record) (no V1 fields) → record valid
 
 :::note
 

--- a/src/ipns/ipns-record.md
+++ b/src/ipns/ipns-record.md
@@ -421,6 +421,28 @@ Value from `IpnsEntry.value` MUST never be used unless it is the same as signed 
 
 ## Appendix: Notes for Implementers
 
+### Test Vectors
+
+Below are test vectors in [Record Serialization Format](#record-serialization-format),
+along with the expected verification results. The records are valid for 100
+years, making them safe for use in CI tests.
+
+1. [V1-only](https://dweb.link/ipfs/bafybeifkipmlz2fehxda6y7x752uolfed7bdd46jzdammpfga5zrnkq33u/k51qzi5uqu5dm4tm0wt8srkg9h9suud4wuiwjimndrkydqm81cqtlb5ak6p7ku_v1.ipns-record) → record invalid
+2. [V1+V2](https://dweb.link/ipfs/bafybeifkipmlz2fehxda6y7x752uolfed7bdd46jzdammpfga5zrnkq33u/k51qzi5uqu5dlkw8pxuw9qmqayfdeh4kfebhmreauqdc6a7c3y7d5i9fi8mk9w_v1-v2.ipns-record) (both signatures valid) → record valid, value points at `/ipfs/bafkqaddwgevxmmraojswg33smq`
+3. [V1+V2](https://dweb.link/ipfs/bafybeifkipmlz2fehxda6y7x752uolfed7bdd46jzdammpfga5zrnkq33u/k51qzi5uqu5dlmit2tuwdvnx4sbnyqgmvbxftl0eo3f33wwtb9gr7yozae9kpw_v1-v2-broken-v1-value.ipns-record) (both signatures valid, but 'value' is different in V1 pb vs V2 CBOR) → record invalid
+4. [V1+V2](https://dweb.link/ipfs/bafybeifkipmlz2fehxda6y7x752uolfed7bdd46jzdammpfga5zrnkq33u/k51qzi5uqu5diamp7qnnvs1p1gzmku3eijkeijs3418j23j077zrkok63xdm8c_v1-v2-broken-signature-v2.ipns-record) (only signatureV1 valid) → record invalid
+5. [V1+V2](https://dweb.link/ipfs/bafybeifkipmlz2fehxda6y7x752uolfed7bdd46jzdammpfga5zrnkq33u/k51qzi5uqu5dilgf7gorsh9vcqqq4myo6jd4zmqkuy9pxyxi5fua3uf7axph4y_v1-v2-broken-signature-v1.ipns-record) (only signatureV2 valid) → record valid, value points at `/ipfs/bafkqahtwgevxmmrao5uxi2bamjzg623fnyqhg2lhnzqxi5lsmuqhmmi`
+6. [V2-only](https://dweb.link/ipfs/bafybeifkipmlz2fehxda6y7x752uolfed7bdd46jzdammpfga5zrnkq33u/k51qzi5uqu5dit2ku9mutlfgwyz8u730on38kd10m97m36bjt66my99hb6103f_v2.ipns-record) (no V1 fields) → record valid
+
+:::note
+
+Implementers can either write own tests against the above test vectors, or run
+[gateway-conformance](https://github.com/ipfs/gateway-conformance/) test suite,
+which includes tests for these vectors since
+[gateway-conformance/pull/157](https://github.com/ipfs/gateway-conformance/pull/157).
+
+:::
+
 ### Integration with IPFS
 
 Below are additional notes for implementers, documenting how IPNS is integrated within IPFS ecosystem.

--- a/src/ipns/ipns-record.md
+++ b/src/ipns/ipns-record.md
@@ -239,7 +239,7 @@ IPNS implementations MUST support sending and receiving a serialized
 `IpnsEntry` less than or equal to **10 KiB** in size.
 
 Records over the limit MAY be ignored. Handling records larger than the
-limit is not recommended so as to keep compatibility with implementations and
+limit is not recommended to keep compatibility with implementations and
 transports that follow this specification.
 
 ### Backward Compatibility
@@ -316,7 +316,7 @@ Creating a new IPNS record MUST follow the below steps:
    serialized copy in `IpnsEntry.pubKey`
 
    - This step SHOULD be skipped for Ed25519, and any other key types that are
-     small enough (32 bytes) to be inlined inside of [IPNS Name](#ipns-name) itself.
+     small enough (32 bytes) to be inlined inside [IPNS Name](#ipns-name) itself.
 
 5. Create `IpnsEntry.signatureV2`
 
@@ -327,9 +327,8 @@ Creating a new IPNS record MUST follow the below steps:
    - Sign concatenated bytes from the previous step using the private key, and
      store the signature in `IpnsEntry.signatureV2`
 
-7. Confirm that the serialized `IpnsEntry` bytes sum to less than or equal to
+6. Confirm that the serialized `IpnsEntry` bytes sum to less than or equal to
    [the size limit](#record-size-limit).
-
 
 Created `IpnsEntry` protobuf includes signed `data` CBOR and optional public key:
 
@@ -357,14 +356,14 @@ the [DAG-CBOR specification](https://ipld.io/specs/codecs/dag-cbor/spec/):
 }
 ```
 
-#### Record Creation: V1+V2 with Legacy V1 Signature
+#### Record Creation with Legacy SignatureV1
 
 :::warning
 
 Fields related to `signatureV1` has been deprecated since 2021.
 V1 signatures are no longer used during record validation.
 
-However it may be necessary to create a V1+V2 record that allows legacy
+However, it may be necessary to create a V2+V1 record that allows legacy
 software to use IPNS to upgrade itself to the latest version which supports V2
 signatures. In such case, follow the steps below.
 
@@ -378,7 +377,7 @@ signatures. In such case, follow the steps below.
    - If you want to store additional metadata in the record, add it under unique keys at `IpnsEntry.data`.
    - The order of fields impacts signature verification. If you are using an alternative CBOR implementation, make sure the CBOR field order follows :cite[rfc7049] sorting rules: length and then bytewise. The order of fields impacts signature verification.
 4. If your public key can't be inlined inside the IPNS Name, include a serialized copy in `IpnsEntry.pubKey`
-   - This step SHOULD be skipped for Ed25519, and any other key types that are inlined inside of [IPNS Name](#ipns-name) itself.
+   - This step SHOULD be skipped for Ed25519, and any other key types that are inlined inside [IPNS Name](#ipns-name) itself.
 5. Create `IpnsEntry.signatureV2`
    - Create bytes for signing by concatenating `ipns-signature:` prefix (bytes in hex: `69706e732d7369676e61747572653a`) with raw CBOR bytes from `IpnsEntry.data`
    - Sign concatenated bytes from the previous step using the private key, and store the signature in `IpnsEntry.signatureV2`
@@ -420,11 +419,13 @@ Implementations MUST ensure `IpnsEntry.signatureV2` is used instead.
 
 Value from `IpnsEntry.value` MUST never be used unless it is the same as signed `IpnsEntry.data[Value]`.
 
-## Integration with IPFS
+## Appendix: Notes for Implementers
+
+### Integration with IPFS
 
 Below are additional notes for implementers, documenting how IPNS is integrated within IPFS ecosystem.
 
-### Local Record
+#### Local Record
 
 This record is stored in the peer's repo datastore and contains the **latest** version of the IPNS record published by the provided key. This record is useful for republishing, as well as tracking the sequence number.
 A legacy convention that implementers MAY want to follow is to store serialized `IpnsEntry` under:
@@ -433,7 +434,7 @@ A legacy convention that implementers MAY want to follow is to store serialized 
 
 Note: Base32 according to the :cite[rfc4648].
 
-### Routing Record
+#### Routing Record
 
 The routing record is spread across the network according to the available routing systems.
 The two routing systems currently available in IPFS are the [libp2p Kademlia DHT](https://github.com/libp2p/specs/tree/master/kad-dht) and :cite[ipns-pubsub-router].
@@ -445,7 +446,11 @@ The two routing systems currently available in IPFS are the [libp2p Kademlia DHT
 
 As the `pubsub` topics must be `utf-8` for interoperability among different implementations, IPNS over PubSub topics use additional wrapping `/record/base64url-unpadded(key)`
 
-### Implementations
+#### Reference Implementations
+
+When language-specific nuances are not covered by this specification, consider
+below reference  implementations as the baseline for making decisions around
+interoperability.
 
 - <https://github.com/ipfs/boxo/tree/main/ipns>
 - <https://github.com/ipfs/js-ipns>

--- a/src/ipns/ipns-record.md
+++ b/src/ipns/ipns-record.md
@@ -3,7 +3,7 @@ title: IPNS Record and Protocol
 description: >
   Specifies the IPNS protocol in a language-agnostic manner, allowing everyone to
   create a compatible IPNS Record Publisher or Resolver.
-date: 2023-02-13
+date: 2023-07-24
 maturity: reliable
 editors:
   - name: Vasco Santos


### PR DESCRIPTION
Closes https://github.com/ipfs/specs/issues/376

This IPIP introduces support for creation and validation of compact, V2-only IPNS Records.

- [x] boxo/ipns implementation
  - done: https://github.com/ipfs/boxo/pull/339
- [x] ping [helia](https://github.com/ipfs/helia) cc @achingbrain  
  - [ ] PR js-ipns implementation (@hacdias) https://github.com/ipfs/js-ipns/pull/234
- [x] ping [ipfs-chromium](https://github.com/little-bear-labs/ipfs-chromium) impl. cc @John-LittleBearLabs
- [x] ping  [nabu](https://github.com/Peergos/nabu) cc @ianopolous
- [x] ping [capyloon](https://capyloon.org/ipfs.html) cc @fabricedesre
- [x] ping [w3name](https://github.com/web3-storage/w3name) cc @alanshaw
- [x] update Test fixtures section after we have them in gateway-conformance