### PR TITLE
gateway: clarify format negotiation precedence

### DIFF
--- a/src/http-gateways/path-gateway.md
+++ b/src/http-gateways/path-gateway.md
@@ -239,6 +239,9 @@ These are the equivalents:
 - `format=cbor` → `Accept: application/cbor`
 - `format=ipns-record` → `Accept: application/vnd.ipfs.ipns-record`
 
+When both `Accept` HTTP header  and `format` query parameter are present,
+`Accept` SHOULD take precedence.
+
 ### `dag-scope` (request query parameter)
 
 Only used on CAR requests, same as :ref[dag-scope] from :cite[trustless-gateway].


### PR DESCRIPTION
Closes #458 cc @SgtPooki 

This was not specified, but `Accept` takes precedence.
The `format` parameter is provided as UX courtesy, mostly used for creating shareable links and download links on websites. `Accept` overrides it, as the content type may have parameters which can only be passed via HTTP header (e.g. [`order` of CAR](https://specs.ipfs.tech/http-gateways/trustless-gateway/#car-order-content-type-parameter))