### PR TITLE
gateway: clarify entiry-bytes out of range

### DIFF
--- a/src/http-gateways/trustless-gateway.md
+++ b/src/http-gateways/trustless-gateway.md
@@ -155,7 +155,7 @@ The following additional values are supported:
 A Gateway MUST augment the returned `Etag` based on the passed `entity-bytes`.
 
 A Gateway SHOULD return an HTTP 400 Bad Request error when the requested range
-cannot be parsed as valid offset positions.
+is outside of valid offset positions in full, and the gateway knows that upfront.
 
 In more nuanced error scenarios, a Gateway MUST return a valid CAR response
 that includes enough blocks for the client to understand why the requested
@@ -163,8 +163,8 @@ that includes enough blocks for the client to understand why the requested
 returned:
 
 - If the requested `entity-bytes` resolves to a range that partially falls
-  outside the entity's byte range, the response MUST include the subset of
-  blocks within the entity's bytes.
+  outside the entity's byte range (before or after),
+  the response MUST include the subset of blocks within the entity's bytes.
   - This allows clients to request valid ranges of the entity without needing
     to know its total size beforehand, and it does not require the Gateway to
     buffer the entire entity before returning the response.


### PR DESCRIPTION
This PR applies cosmetic spec clarification based on discussion that happened in  https://github.com/ipfs/boxo/pull/523 and was released in [gateway-conformance@v0.5](https://github.com/ipfs/gateway-conformance/releases/tag/v0.5.0) 

cc @rvagg @hannahhoward 