### PR TITLE
gateway: explain why we normalize to trailing slash in dir URLs

### DIFF
--- a/src/http-gateways/path-gateway.md
+++ b/src/http-gateways/path-gateway.md
@@ -524,10 +524,10 @@ without the trailing `/`, for example:
  (no trailing slash) MUST be HTTP 301 redirect with
   `Location: /ipns/en.wikipedia-on-ipfs.org/wiki/`
 
-This normalization is required for directory-based relative links 
+This normalization is required for directory-based relative links
 and security scopes such as Service Worker registrations to work correctly.
 It also ensures the same behavior on path gateways (`https://example.com/ipfs/cid/` with trailing `/`)
-and origin-isolated HTTP contexts `https://cid.ipfs.dweb.link` 
+and origin-isolated HTTP contexts `https://cid.ipfs.dweb.link`
 or non-HTTP URLs like `ipfs://cid`, where empty path component is implicit `/`.
 
 ### `X-Ipfs-Path` (response header)

--- a/src/http-gateways/path-gateway.md
+++ b/src/http-gateways/path-gateway.md
@@ -520,9 +520,15 @@ This header is more widely used in [SUBDOMAIN_GATEWAY.md](./SUBDOMAIN_GATEWAY.md
 Gateway MUST return a redirect when a valid UnixFS directory was requested
 without the trailing `/`, for example:
 
-- response for `https://ipfs.io/ipns/en.wikipedia-on-ipfs.org/wiki`
- (no trailing slash) will be HTTP 301 redirect with
+- response for UnixFS directory at `https://example.com/ipns/en.wikipedia-on-ipfs.org/wiki`
+ (no trailing slash) MUST be HTTP 301 redirect with
   `Location: /ipns/en.wikipedia-on-ipfs.org/wiki/`
+
+This normalization is required for directory-based relative links 
+and security scopes such as Service Worker registrations to work correctly.
+It also ensures the same behavior on path gateways (`https://example.com/ipfs/cid/` with trailing `/`)
+and origin-isolated HTTP contexts `https://cid.ipfs.dweb.link` 
+or non-HTTP URLs like `ipfs://cid`, where empty path component is implicit `/`.
 
 ### `X-Ipfs-Path` (response header)
 


### PR DESCRIPTION
Clarification prompted by discussion in https://github.com/ipfs-shipyard/helia-service-worker-gateway/issues/62 as it felt the reason we do this was not clear enough. 

Suggestions on wording/examples appreciated.