### PR TITLE
/routing/v1: add missing HTTP cache headers

### DIFF
--- a/src/routing/http-routing-v1.md
+++ b/src/routing/http-routing-v1.md
@@ -74,7 +74,7 @@ This API uses a standard version prefix in the path, such as `/v1/...`. If a bac
 #### Response Headers
 
 - `Content-Type`: the content type of this response, which MUST be `application/json` or `application/x-ndjson` (see [streaming](#streaming)).
-- `Last-Modified`: the timestamp of the resolution, allowing CDNs and load balancers to support inexpensive update checks via `If-Modified-Since`
+- `Last-Modified`: an HTTP-date timestamp ([RFC9110, Section 5.6.7](https://www.rfc-editor.org/rfc/rfc9110#section-5.6.7)) of the resolution, allowing HTTP proxies and CDNs to support inexpensive update checks via `If-Modified-Since`
 - `Cache-Control: public, max-age={ttl}, public, stale-while-revalidate={max-ttl}, stale-if-error={max-ttl}`: meaningful cache TTL returned with the response.
   - The `max-age` SHOULD be shorter for responses whose resolution ended in no results (e.g. 15 seconds),
     and longer for responses that have results (e.g. 5 minutes).
@@ -122,7 +122,7 @@ represented as a CIDv1 encoded with `libp2p-key` codec.
 #### Response Headers
 
 - `Content-Type`: the content type of this response, which MUST be `application/json` or `application/x-ndjson` (see [streaming](#streaming)).
-- `Last-Modified`: the timestamp of the resolution, allowing CDNs and load balancers to support inexpensive update checks via `If-Modified-Since`
+- `Last-Modified`: an HTTP-date timestamp ([RFC9110, Section 5.6.7](https://www.rfc-editor.org/rfc/rfc9110#section-5.6.7)) of the resolution, allowing HTTP proxies and CDNs to support inexpensive update checks via `If-Modified-Since`
 - `Cache-Control: public, max-age={ttl}, public, stale-while-revalidate={max-ttl}, stale-if-error={max-ttl}`: meaningful cache TTL returned with the response.
   - When present, `ttl` SHOULD be shorter for responses whose resolution ended in no results (e.g. 15 seconds),
     and longer for responses that have results (e.g. 5 minutes).
@@ -173,8 +173,8 @@ Each object in the `Peers` list is a record conforming to the [Peer Schema](#pee
 - `Cache-Control: public, max-age={ttl}, public, stale-while-revalidate={sig-ttl}, stale-if-error={sig-ttl}`: meaningful cache TTL returned with :ref[IPNS Record]
   - The `max-age` value in seconds SHOULD match duration from `IpnsEntry.data[TTL]`, if present and bigger than `0`. Otherwise, implementation SHOULD default to `max-age=60`.
   - Implementations SHOULD include `sig-ttl`, set to the remaining number of seconds the returned IPNS Record is valid.
-- `Expires: {SIGNATURE_EXPIRATION}`: header with time when the signature expires.
-- `Last-Modified`: the timestamp of cacheable resolution, allowing CDNs and load balancers to support inexpensive update checks via `If-Modified-Since`
+- `Expires:`: an HTTP-date timestamp ([RFC9110, Section 5.6.7](https://www.rfc-editor.org/rfc/rfc9110#section-5.6.7)) when the validity of IPNS Record expires (if `ValidityType=0`, when signature expires)
+- `Last-Modified`: an HTTP-date timestamp of when cacheable resolution occured: allows HTTP proxies and CDNs to support inexpensive update checks via `If-Modified-Since`
 - `Vary: Accept`: allows intermediate caches to play nicely with the different possible content types.
 
 #### Response Body

--- a/src/routing/http-routing-v1.md
+++ b/src/routing/http-routing-v1.md
@@ -71,6 +71,13 @@ This API uses a standard version prefix in the path, such as `/v1/...`. If a bac
 - `404` (Not Found): must be returned if no matching records are found.
 - `422` (Unprocessable Entity): request does not conform to schema or semantic constraints.
 
+#### Response Headers
+
+- `Content-Type`: the content type of this response, which MUST be `application/json` or `application/x-ndjson` (see [streaming](#streaming)).
+- `Last-Modified`: the timestamp of the resolution.
+- `Cache-Control: public, max-age={TTL}`: cache TTL returned with the response. When present, it SHOULD be short for responses that do whose resolution ended in no results (e.g. 15 seconds), and MAY be longer for responses that have results (e.g. 5 minutes).
+- `Vary: Accept`: allows intermediate caches to play nicely with the different possible content types.
+
 #### Response Body
 
 ```json
@@ -107,6 +114,13 @@ represented as a CIDv1 encoded with `libp2p-key` codec.
 - `200` (OK): the response body contains the peer record.
 - `404` (Not Found): must be returned if no matching records are found.
 - `422` (Unprocessable Entity): request does not conform to schema or semantic constraints.
+
+#### Response Headers
+
+- `Content-Type`: the content type of this response, which MUST be `application/json` or `application/x-ndjson` (see [streaming](#streaming)).
+- `Last-Modified`: the timestamp of the resolution.
+- `Cache-Control: public, max-age={TTL}`: cache TTL returned with the response. When present, it SHOULD be short for responses that do whose resolution ended in no results (e.g. 15 seconds), and MAY be longer for responses that have results (e.g. 5 minutes).
+- `Vary: Accept`: allows intermediate caches to play nicely with the different possible content types.
 
 #### Response Body
 
@@ -148,7 +162,9 @@ Each object in the `Peers` list is a record conforming to the [Peer Schema](#pee
 #### Response Headers
 
 - `Etag`: a globally unique opaque string used for HTTP caching. MUST be derived from the protobuf record returned in the body.
-- `Cache-Control: max-age={TTL}`: cache TTL returned with :ref[IPNS Record] that has `IpnsEntry.data[TTL] > 0`. When present, SHOULD match the TTL value from the record. When record was not found (HTTP 404) or has no TTL (value is `0`), implementation SHOULD default to `max-age=60`.
+- `Cache-Control: public, max-age={TTL}`: cache TTL returned with :ref[IPNS Record] that has `IpnsEntry.data[TTL] > 0`. When present, SHOULD match the TTL value from the record. When record was not found (HTTP 404) or has no TTL (value is `0`), implementation SHOULD default to `max-age=60`. Implementations MAY also include other derivatives, such as `stale-while-revalidate` and `stale-if-error`.
+- `Expires: {SIGNATURE_EXPIRATION}`: header with time when the signature expires.
+- `Last-Modified`: with the timestamp of the resolution.
 
 #### Response Body
 

--- a/src/routing/http-routing-v1.md
+++ b/src/routing/http-routing-v1.md
@@ -75,7 +75,7 @@ This API uses a standard version prefix in the path, such as `/v1/...`. If a bac
 
 - `Content-Type`: the content type of this response, which MUST be `application/json` or `application/x-ndjson` (see [streaming](#streaming)).
 - `Last-Modified`: the timestamp of the resolution.
-- `Cache-Control: public, max-age={TTL}`: cache TTL returned with the response. When present, it SHOULD be short for responses that do whose resolution ended in no results (e.g. 15 seconds), and MAY be longer for responses that have results (e.g. 5 minutes).
+- `Cache-Control: public, max-age={TTL}`: cache TTL returned with the response. When present, it SHOULD be short for responses whose resolution ended in no results (e.g. 15 seconds), and MAY be longer for responses that have results (e.g. 5 minutes).
 - `Vary: Accept`: allows intermediate caches to play nicely with the different possible content types.
 
 #### Response Body
@@ -119,7 +119,7 @@ represented as a CIDv1 encoded with `libp2p-key` codec.
 
 - `Content-Type`: the content type of this response, which MUST be `application/json` or `application/x-ndjson` (see [streaming](#streaming)).
 - `Last-Modified`: the timestamp of the resolution.
-- `Cache-Control: public, max-age={TTL}`: cache TTL returned with the response. When present, it SHOULD be short for responses that do whose resolution ended in no results (e.g. 15 seconds), and MAY be longer for responses that have results (e.g. 5 minutes).
+- `Cache-Control: public, max-age={TTL}`: cache TTL returned with the response. When present, it SHOULD be short for responses whose resolution ended in no results (e.g. 15 seconds), and MAY be longer for responses that have results (e.g. 5 minutes).
 - `Vary: Accept`: allows intermediate caches to play nicely with the different possible content types.
 
 #### Response Body


### PR DESCRIPTION
Request from https://github.com/ipfs/boxo/pull/584/.