### PR TITLE
Typo Update ARCHITECTURE.md

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # ![](https://img.shields.io/badge/status-wip-orange.svg?style=flat-square) IPFS Architecture Overview
 
 
-**Authors(s)**:
+**Author(s)**:
 - [Juan Benet](https://github.com/jbenet)
 - [David Dias](https://github.com/daviddias)
 


### PR DESCRIPTION
"Authors(s)" should be corrected to "Author(s)" (singular or plural).

Corrected.