### PR TITLE
chore: clarify accepted Peer IDs

### DIFF
--- a/src/routing/http-routing-v1.md
+++ b/src/routing/http-routing-v1.md
@@ -52,7 +52,7 @@ As such, human-readable encodings of types are preferred. This specification may
 
 - CIDs are always string-encoded using a [multibase]-encoded [CIDv1].
 - Multiaddrs are string-encoded according to the [human-readable multiaddr specification][multiaddr].
-- Peer IDs are string-encoded according [PeerID string representation specification][peer-id-representation]: either a Multihash in Base58btc, or a CIDv1 with libp2p-key (`0x72`) codec.
+- Peer IDs are string-encoded according [PeerID string representation specification][peer-id-representation]: either a Multihash in Base58btc, or a CIDv1 with libp2p-key (`0x72`) codec in Base36 or Base32.
 - Multibase bytes are string-encoded according to [the Multibase spec][multibase], and SHOULD use base64.
 - Timestamps are Unix millisecond epoch timestamps.
 
@@ -68,7 +68,7 @@ This API uses a standard version prefix in the path, such as `/v1/...`. If a bac
 
 #### Path Parameters
 
-- `cid` is the [CID](https://github.com/multiformats/cid) to fetch provider records for.
+- `cid` is the [CID](https://github.com/multiformats/cid) to fetch provider records for (preferably normalized to a CIDv1 in Base32, to maximize HTTP cache hits).
 
 #### Request Query Parameters
 

--- a/src/routing/http-routing-v1.md
+++ b/src/routing/http-routing-v1.md
@@ -148,7 +148,7 @@ Each object in the `Providers` list is a record conforming to a schema, usually 
 #### Path Parameters
 
 - `peer-id` is the [Peer ID](https://github.com/libp2p/specs/blob/master/peer-ids/peer-ids.md) to fetch peer records for,
-represented as either a Multihash in Base58btc, or a CIDv1 with libp2p-key (`0x72`) codec. 
+represented as either a Multihash in Base58btc, or a CIDv1 with libp2p-key (`0x72`) codec (in Base36 or Base32).
 
 #### Request Query Parameters
 

--- a/src/routing/http-routing-v1.md
+++ b/src/routing/http-routing-v1.md
@@ -148,7 +148,7 @@ Each object in the `Providers` list is a record conforming to a schema, usually 
 #### Path Parameters
 
 - `peer-id` is the [Peer ID](https://github.com/libp2p/specs/blob/master/peer-ids/peer-ids.md) to fetch peer records for,
-represented as a CIDv1 encoded with `libp2p-key` codec.
+represented as either a Multihash in Base58btc, or a CIDv1 with libp2p-key (`0x72`) codec. 
 
 #### Request Query Parameters
 


### PR DESCRIPTION
Clarify that the delegated routing peer routing endpoint accepts both CID and Multihash encoded PeerIDs