### PR TITLE
ipns: lower the suggested default TTL

### DIFF
--- a/src/ipns/ipns-record.md
+++ b/src/ipns/ipns-record.md
@@ -3,7 +3,7 @@ title: IPNS Record and Protocol
 description: >
   Specifies the IPNS protocol in a language-agnostic manner, allowing everyone to
   create a compatible IPNS Record Publisher or Resolver.
-date: 2023-10-03
+date: 2025-02-28
 maturity: reliable
 editors:
   - name: Vasco Santos

--- a/src/ipns/ipns-record.md
+++ b/src/ipns/ipns-record.md
@@ -160,7 +160,7 @@ A logical :dfn[IPNS Record] is a data structure containing the following fields:
 
 - A hint for how long (in nanoseconds) the record should be cached before going back to, for instance the DHT, in order to check if it has been updated. The function and trade-offs of this value are analogous to the TTL of DNS record.
 - Implementations MUST include this value inside the DAG-CBOR document at `IpnsEntry.data[TTL]`.
-- Suggested default: 1 hour (3 600 000 000 000 nanoseconds).
+- Suggested default: 5 minutes (300 000 000 000 nanoseconds).
 
 #### :dfn[Public Key]{also="ipns-record-public-key"} (bytes)
 


### PR DESCRIPTION
Adjusting the suggested default due to the rationale from https://github.com/ipfs/kubo/issues/10718

Reference implementation changes:
- `boxo/ipfs.DefaultRecordTTL`: https://github.com/ipfs/boxo/pull/859
- `@helia/ipns`: https://github.com/ipfs/helia/pull/749