### PR TITLE
gateway: clarify 3XX on trustless gw

### DIFF
--- a/src/http-gateways/path-gateway.md
+++ b/src/http-gateways/path-gateway.md
@@ -314,8 +314,11 @@ A generic client error returned when it is not possible to return a better one
 
 ### `404` Not Found
 
-Error to indicate that request was formally correct, but traversal of the
-requested content path was not possible due to a invalid or missing DAG node.
+Error indicating that the request was syntactically valid, but traversal
+of the requested content path failed due to an invalid or missing DAG node.
+
+This error SHOULD occur when either the root CID is not provided by the gateway
+or a specified sub-path does not exist within the DAG referenced by the root CID.
 
 ### `410` Gone
 

--- a/src/http-gateways/trustless-gateway.md
+++ b/src/http-gateways/trustless-gateway.md
@@ -235,6 +235,25 @@ In case both are present in the request, the value from the [`Accept`](#accept-r
 
 Below MUST be implemented **in addition** to "HTTP Response" of :cite[path-gateway].
 
+## Response Status Codes
+
+### `200` OK
+
+The request succeeded.
+
+If the HTTP method was `GET`, then data is transmitted in the message body.
+
+### `404` Not Found
+
+Error to indicate that requested resource is not provided by the gateway.
+
+### `3XX` Redirects
+
+Non-recursive trustless gateway SHOULD NOT return HTTP redirects.
+Change of URL should occur by announcing it to the routing system.
+
+Clients SHOULD ignore redirects and interpret them the same way as `404`.
+
 ## Response Headers
 
 ### `Content-Type` (response header)


### PR DESCRIPTION
> Writing down clarification proposed by @hsanjuan idea from https://github.com/ipfs/boxo/issues/862#issuecomment-2693727250

- 3XX create unnecessary overhead for  trustless clients and non-recursive servers
- it is desirable for spec to nudge implementers towards best practices that remove redirect overhead from server and client and shift solution to updating entry in routing system

