### PR TITLE
Spec for CIDs

### DIFF
--- a/src/architecture/principles.md
+++ b/src/architecture/principles.md
@@ -12,10 +12,9 @@ editors:
     url: https://berjon.com/
     github: darobin
     twitter: robinberjon
-    mastodon: "@robin@mastodon.social"
     affiliation:
-        name: Protocol Labs
-        url: https://protocol.ai/
+        name: IPFS Foundation
+        url: https://ipfsfoundation.org/
 tags: ['architecture']
 order: 0
 xref:

--- a/src/data-formats/cid.md
+++ b/src/data-formats/cid.md
@@ -79,6 +79,10 @@ Where
 
 - `<multibase-codec>` is a [multibase](https://github.com/multiformats/multibase) prefix  (1 Unicode code point in length) that renders the base-encoded unicode string following it self-describing for simpler conversion back to binary.
 
+A CID is fundamentally a binary value.
+The multibase prefix identifies the string encoding but is not part of the CID itself -- the same CID may be encoded in different bases for different contexts.
+IPFS implementations SHOULD support at minimum `base58btc`, `base32`, `base16`, and `base36` (the latter for ed25519 keys in [IPNS Records](https://specs.ipfs.tech/ipns/ipns-record/)).
+
 ## Variant - Human-Readable Form
 
 It is often advantageous to translate a CID, which is already modular and self-describing, into a *human-readable* expansion of its self-describing parts, for purposes such as debugging, unit testing, and documentation.
@@ -164,6 +168,9 @@ These sections provide additional context. This is not part of specification,
 and is provided here only for extra context.
 :::
 
+<!-- TODO: review each implementation for spec conformance before listing here.
+     A spec should not reference implementations that may not follow it.
+
 ## Implementations
 
 - [go-cid](https://github.com/ipfs/go-cid)
@@ -174,7 +181,8 @@ and is provided here only for extra context.
 - [elixir-cid](https://github.com/nocursor/ex-cid)
 - [dart_cid](https://github.com/dwyl/dart_cid)
 - [zig_cid](https://github.com/zen-eth/multiformats-zig)
-- [Add yours today!](https://github.com/multiformats/cid/edit/master/README.md)
+
+-->
 
 ## FAQ
 
@@ -184,21 +192,19 @@ Please check their repositories: [multicodec](https://github.com/multiformats/mu
 
 > **Q. Why does CID exist?**
 
-We were using base58btc encoded multihashes in IPFS, and then we needed to switch formats to IPLD.
-We struggled with lots of problems of addressing data with different formats until we created CIDs.
-You can read the history of this format here: https://github.com/ipfs/specs/issues/130
+IPFS originally used base58btc-encoded multihashes, but the need to support multiple data formats via IPLD revealed limitations of bare multihashes as identifiers.
+CIDs were created to provide a self-describing, versioned, typed content address.
+The history of this format is documented at: https://github.com/ipfs/specs/issues/130
 
 > **Q. Is the use of multicodec similar to file extensions?**
 
-Yes, kind of! like a file extension, the multicodec identifier establishes the format of the data.
-Unlike file extensions, these are in the middle of the identifier and not meant to be changed by users.
-There is also a short table of supported formats.
+Yes. Like a file extension, the multicodec in a CID tells consumers how to interpret the bytes.
+And just like file extensions, most users will never change it, but it is technically possible to swap the codec to change how the same bytes behind a CID are parsed.
 
 > **Q. What formats (multicodec codes) does CID support?**
 
-We are figuring this out at this time.
-It will likely be a subset of [multicodecs](https://github.com/multiformats/multicodec/blob/master/table.csv) for secure distributed systems.
-So far, we want to address IPFS's UnixFS and raw blocks ([`dag-pb`](https://ipld.io/specs/codecs/dag-pb/spec/), [`raw`](https://www.iana.org/assignments/media-types/application/vnd.ipld.raw)), IPNS's [`libp2p-key`](https://github.com/libp2p/specs/blob/master/RFC/0001-text-peerid-cid.md), and IPLD's [`dag-json`](https://ipld.io/specs/codecs/dag-json/spec/)/[`dag-cbor`](https://ipld.io/specs/codecs/dag-cbor/spec/) formats.
+CID can reference content of any type registered in the [multicodec table](https://github.com/multiformats/multicodec/blob/master/table.csv).
+In practice, IPFS primarily uses [`dag-pb`](https://web.archive.org/web/20260305020653/https://ipld.io/specs/codecs/dag-pb/spec/) (`0x70`), [`raw`](https://www.iana.org/assignments/media-types/application/vnd.ipld.raw) (`0x55`), [`dag-cbor`](https://web.archive.org/web/20260305020653/https://ipld.io/specs/codecs/dag-cbor/spec/) (`0x71`), [`dag-json`](https://web.archive.org/web/20260305020653/https://ipld.io/specs/codecs/dag-json/spec/) (`0x0129`), and [`libp2p-key`](https://github.com/libp2p/specs/blob/4e2c796bc77a2639136b277224468b7c48b9fff1/RFC/0001-text-peerid-cid.md) (`0x72`).
 
 > **Q. What is the process for updating CID specification (e.g., adding a new version)?**
 
@@ -210,4 +216,4 @@ Due to this, changes to CID specification MUST be submitted as an improvement pr
 
 ## Historical Design Decisions
 
-You can read an [in-depth discussion on why this format was needed in IPFS](https://github.com/ipfs/specs/issues/130).
+You can read an [in-depth discussion on why this format was needed in IPFS](https://github.com/ipfs/specs/issues/130) and the [original CIDv1 proposal](https://github.com/multiformats/cid/blob/f638ca68390758f0d4c7f90ac843091d3973cd02/original-rfc.md).

--- a/src/data-formats/cid.md
+++ b/src/data-formats/cid.md
@@ -135,10 +135,10 @@ CIDs design takes into account many difficult tradeoffs encountered while buildi
 ### CIDv0
 
 CIDv0 is a backwards-compatible version, where:
-- the `multibase` of the string representation is always `base58btc` and implicit (not written)
-- the `multicodec` is always `dag-pb` and implicit (not written)
-- the `cid-version` is always `cidv0` and implicit (not written)
-- the `multihash` is written as is but is always a full (length 32) sha256 hash.
+- the `multibase` of the string representation is always `base58btc` and implicit (prefix `z` not present)
+- the `multicodec` is always `dag-pb` (`0x70`) and implicit (not written)
+- the `cid-version` is always `cidv0` (`0`) and implicit (not written)
+- the `multihash` is written as is but is always a full (length 32) `sha2-256` (`0x12`) hash.
 
 ```text
 cidv0 ::= <multihash-content-address>
@@ -154,7 +154,7 @@ See the section: [How does it work?](#how-does-it-work)
 
 ## Decoding Algorithm
 
-To decode a CID, follow the following algorithm:
+To decode a CID, follow this algorithm:
 
 1. If it's a string (ASCII/UTF-8):
    * If it is 46 characters long and starts with `Qm`, it's a CIDv0. Decode it as base58btc and continue to step 2.

--- a/src/data-formats/cid.md
+++ b/src/data-formats/cid.md
@@ -80,21 +80,20 @@ Where
 
 ## Variant - Stringified Form
 
-Since CIDs have many applications outside of binary-only contexts, a given CID may need to be base-encoded multiple ways for different consumers or for different transports.
-In such applications, CIDs are often expressed as a Unicode *string* rather than a bytestring, which adds a single code-point prefix.
-In these contexts, then, the full string form is:
+Since CIDs have many applications outside of binary-only contexts, a given CID may need to be base-encoded for different consumers or transports.
+In such applications, CIDs are expressed as a Unicode *string* with a [multibase](https://github.com/multiformats/multibase) prefix.
+The multibase prefix identifies the string encoding but is not part of the CID itself -- the same binary CID may be represented in different bases depending on context and needs such as string length and case-sensitivity.
+The full string form is:
 
 ```text
-<cidv1-str> ::= <multibase-codec><multibase-encoding(<CIDv1-multicodec><multicodec><multihash>)>
+<cidv1-str> ::= <multibase-prefix><multibase-encoding(<CIDv1-multicodec><multicodec><multihash>)>
 ```
 
 Where
 
-- `<multibase-codec>` is a [multibase](https://github.com/multiformats/multibase) prefix (1 Unicode code point in length) that renders the base-encoded unicode string following it self-describing for simpler conversion back to binary.
+- `<multibase-prefix>` is a [multibase prefix](https://github.com/multiformats/multibase/blob/master/multibase.csv) (1 Unicode code point) that makes the string self-describing for conversion back to binary.
 
-A CID is fundamentally a binary value.
-The multibase prefix identifies the string encoding but is not part of the CID itself -- the same CID may be encoded in different bases for different contexts.
-IPFS implementations SHOULD support at minimum `base58btc`, `base32`, `base16`, and `base36` (the latter for ed25519 keys in [IPNS Records](https://specs.ipfs.tech/ipns/ipns-record/)).
+IPFS implementations SHOULD support at minimum `base58btc` (`z`), `base32` (`b`), `base16` (`f`), and `base36` (`k`, for ed25519 keys in [IPNS Records](https://specs.ipfs.tech/ipns/ipns-record/)).
 
 ## Variant - Human-Readable Form
 

--- a/src/data-formats/cid.md
+++ b/src/data-formats/cid.md
@@ -141,22 +141,21 @@ See the section: [How does it work?](#how-does-it-work)
 To decode a CID, follow the following algorithm:
 
 1. If it's a string (ASCII/UTF-8):
-* If it is 46 characters long and starts with `Qm...`, it's a CIDv0. Decode it as base58btc and continue to step 2.
-* Otherwise, decode it according to the multibase spec and:
-  * If the first decoded byte is 0x12, return an error. CIDv0 CIDs may not be multibase encoded and there will be no CIDv18 (0x12 = 18) to prevent ambiguity with decoded CIDv0s.
-  * Otherwise, you now have a binary CID. Continue to step 2.
-1. Given a (binary) CID (`cid`):
-* If it's 34 bytes long with the leading bytes `[0x12, 0x20, ...]`, it's a CIDv0.
-  * The CID's multihash is `cid`.
-  * The CID's multicodec is DagProtobuf
-  * The CID's version is 0.
-* Otherwise, let `N` be the first varint in `cid`. This is the CID's version.
-  * If `N == 0x01` (CIDv1):
-    * The CID's multicodec is the second varint in `cid`
-    * The CID's multihash is the rest of the `cid` (after the second varint).
-    * The CID's version is 1.
-  * If `N == 0x02` (CIDv2), or `N == 0x03` (CIDv3), the CID version is reserved.
-  * If `N` is equal to some other multicodec, the CID is malformed.
+   * If it is 46 characters long and starts with `Qm`, it's a CIDv0. Decode it as base58btc and continue to step 2.
+   * Otherwise, decode it according to the multibase spec and:
+     * If the first decoded byte is `0x12`, return an error. CIDv0 CIDs may not be multibase encoded and there will be no CIDv18 (`0x12` = 18) to prevent ambiguity with decoded CIDv0s.
+     * Otherwise, you now have a binary CID. Continue to step 2.
+2. Given a (binary) CID (`cid`):
+   * If the first two bytes are `[0x12, 0x20]` (the `sha2-256` multihash function code followed by digest length 32), it's a CIDv0.
+     * The CID's multihash is `cid` (34 bytes: 2-byte prefix + 32-byte digest).
+     * The CID's multicodec is `dag-pb` (`0x70`), implicit.
+     * The CID's version is 0.
+   * Otherwise, read the first varint in `cid`. This is the CID's version.
+     * If `0x01` (CIDv1):
+       * The CID's multicodec is the second varint in `cid`.
+       * The CID's multihash is the rest of `cid` (after the second varint).
+       * The CID's version is 1.
+     * Otherwise, the CID is malformed.
 
 # Appendices
 

--- a/src/data-formats/cid.md
+++ b/src/data-formats/cid.md
@@ -26,11 +26,11 @@ tags: ['data-formats']
 order: 1
 ---
 
-**CID** is a format for referencing content in distributed information systems, like [IPFS](https://ipfs.io).
+**CID** is a format for referencing content in distributed information systems, like [IPFS](https://ipfs.tech).
 It leverages [content addressing](https://en.wikipedia.org/wiki/Content-addressable_storage),
 [cryptographic hashing](https://simple.wikipedia.org/wiki/Cryptographic_hash_function), and
 [self-describing formats](https://github.com/multiformats/multiformats).
-It is the core identifier used by [IPFS](https://ipfs.io) and [IPLD](https://ipld.io).
+It is the core identifier used by [IPFS](https://ipfs.tech) and [IPLD](https://ipld.io).
 It uses a [multicodec](https://github.com/multiformats/multicodec) to indicate its version, making it fully self describing.
 
 ## What is it?
@@ -39,10 +39,10 @@ A CID is a self-describing content-addressed identifier.
 It uses cryptographic hashes to achieve content addressing. It uses several
 [multiformats](https://github.com/multiformats/multiformats) to achieve flexible self-description, namely:
 
-1. [multihash](https://github.com/multiformats/multihash) to hash content addressed, and
+1. [multihash](https://github.com/multiformats/multihash) for content-addressed hashing, and
 2. [multicodec](https://github.com/multiformats/multicodec) to type that addressed content,
 to form a binary self-contained identifier, and optionally also
-3. [multibase](https://github.com/multiformats/multibase) to encode that binary CID as a  string.
+3. [multibase](https://github.com/multiformats/multibase) to encode that binary CID as a string.
 
 Concretely, it's a *typed* content address: a tuple of `(content-type, content-address)`.
 
@@ -72,12 +72,12 @@ In such applications, CIDs are often expressed as a Unicode *string* rather than
 In these contexts, then, the full string form is:
 
 ```text
-<cidv1> ::= <multibase-codec><multibase-encoding(<CIDv1-multicodec><multicodec><multihash>)>
+<cidv1-str> ::= <multibase-codec><multibase-encoding(<CIDv1-multicodec><multicodec><multihash>)>
 ```
 
 Where
 
-- `<multibase-codec>` is a [multibase](https://github.com/multiformats/multibase) prefix  (1 Unicode code point in length) that renders the base-encoded unicode string following it self-describing for simpler conversion back to binary.
+- `<multibase-codec>` is a [multibase](https://github.com/multiformats/multibase) prefix (1 Unicode code point in length) that renders the base-encoded unicode string following it self-describing for simpler conversion back to binary.
 
 A CID is fundamentally a binary value.
 The multibase prefix identifies the string encoding but is not part of the CID itself -- the same CID may be encoded in different bases for different contexts.

--- a/src/data-formats/cid.md
+++ b/src/data-formats/cid.md
@@ -1,0 +1,214 @@
+---
+title: CID (Content IDentifier)
+description: >
+    Self-describing content-addressed identifiers for distributed systems
+date: 2026-03-12
+maturity: permanent
+editors:
+  - name: Marcin Rataj
+    github: lidel
+    affiliation:
+      name: Interplanetary Shipyard
+      url: https://ipshipyard.com/
+  - name: Robin Berjon
+    email: robin@berjon.com
+    url: https://berjon.com/
+    github: darobin
+    twitter: robinberjon
+    affiliation:
+        name: IPFS Foundation
+        url: https://ipfsfoundation.org/
+former_editors:
+  - name: Juan Benet
+    github: jbenet
+
+tags: ['data-formats']
+order: 1
+---
+
+**CID** is a format for referencing content in distributed information systems, like [IPFS](https://ipfs.io). 
+It leverages [content addressing](https://en.wikipedia.org/wiki/Content-addressable_storage), 
+[cryptographic hashing](https://simple.wikipedia.org/wiki/Cryptographic_hash_function), and 
+[self-describing formats](https://github.com/multiformats/multiformats). 
+It is the core identifier used by [IPFS](https://ipfs.io) and [IPLD](https://ipld.io). 
+It uses a [multicodec](https://github.com/multiformats/multicodec) to indicate its version, making it fully self describing.
+
+## What is it?
+
+A CID is a self-describing content-addressed identifier. 
+It uses cryptographic hashes to achieve content addressing. It uses several 
+[multiformats](https://github.com/multiformats/multiformats) to achieve flexible self-description, namely:
+
+1. [multihash](https://github.com/multiformats/multihash) to hash content addressed, and
+2. [multicodec](https://github.com/multiformats/multicodec) to type that addressed content,
+to form a binary self-contained identifier, and optionally also
+3. [multibase](https://github.com/multiformats/multibase) to encode that binary CID as a  string.
+
+Concretely, it's a *typed* content address: a tuple of `(content-type, content-address)`.
+
+## How does it work?
+
+Current version: CIDv1.
+
+CIDv1 is a **binary** format composed of [unsigned varints](https://github.com/multiformats/unsigned-varint) 
+prefixing a hash digest to form a self-describing "content address":
+
+```text
+<cidv1> ::= <CIDv1-multicodec><content-type-multicodec><content-multihash>
+# or, expanded:
+<cidv1> ::= <`0x01`, the code for `CIDv1`><another code from `ipld` entries in multicodec table that signals content type of data being addressed><multihash of addressed data>
+```
+
+Where
+
+- `<multicodec-cidv1>` is a [multicodec](https://github.com/multiformats/multicodec) representing the version of CID, here for upgradability purposes.
+- `<multicodec-content-type>` is a [multicodec](https://github.com/multiformats/multicodec) code representing the content type or format of the data being addressed.
+- `<multihash-content-address>` is a [multihash](https://github.com/multiformats/multihash) value, which uses a registry of hash function abbreviations to prefix a cryptographic hash of the content being addressed, thus making it self-describing.
+
+## Variant - Stringified Form
+
+Since CIDs have many applications outside of binary-only contexts, a given CID may need to be base-encoded multiple ways for different consumers or for different transports. 
+In such applications, CIDs are often expressed as a Unicode *string* rather than a bytestring, which adds a single code-point prefix. 
+In these contexts, then, the full string form is:
+
+```text
+<cidv1> ::= <multibase-codec><multibase-encoding(<CIDv1-multicodec><multicodec><multihash>)>
+```
+
+Where
+
+- `<multibase-codec>` is a [multibase](https://github.com/multiformats/multibase) prefix  (1 Unicode code point in length) that renders the base-encoded unicode string following it self-describing for simpler conversion back to binary.
+
+## Variant - Human-Readable Form
+
+It is often advantageous to translate a CID, which is already modular and self-describing, into a *human-readable* expansion of its self-describing parts, for purposes such as debugging, unit testing, and documentation. 
+We can easily transform a Stringified CID to a "Human-Readable CID" by translating and segmenting its constituent parts as follows:
+
+```text
+<hr-cid> ::= <hr-mbc> "-" <hr-cid-mc> "-" <hr-mc> "-" <hr-mh>
+```
+Where each sub-component is replaced with its own human-readable form from the relevant registry:
+
+- `<hr-mbc>` is the name of the multibase code (eg `z`--> `base58btc`)
+- `<hr-cid-mc>` is the name of the multicodec for the version of CID used (eg `0x01` --> `cidv1`)
+- `<hr-mc>` is the name of the multicodec code (eg `0x51` --> `cbor`)
+- `<hr-mh>` is the name of the multihash code (eg `sha2-256-256`) followed by a final dash and the hash itself `-abcdef0123456789...`)
+
+For example:
+
+```text
+# example CID
+zb2rhe5P4gXftAwvA4eXQ5HJwsER2owDyS9sKaQRRVQPn93bA
+# corresponding human readable CID
+base58btc - cidv1 - raw - sha2-256-256-6e6ff7950a36187a801613426e858dce686cd7d7e3c0fc42ee0330072d245c95
+```
+See: https://cid.ipfs.io/#zb2rhe5P4gXftAwvA4eXQ5HJwsER2owDyS9sKaQRRVQPn93bA
+
+## Design Considerations
+
+CIDs design takes into account many difficult tradeoffs encountered while building [IPFS](https://ipfs.tech). These are mostly coming from the multiformats project.
+
+- Compactness: CIDs are binary in nature to ensure these are as compact as possible, as they're meant to be part of longer path identifiers or URIs.
+- Transport friendliness (or "copy-pastability"): CIDs are encoded with multibase to allow choosing the best base for transporting. For example, CIDs can be encoded into base58btc to yield shorter and easily-copy-pastable hashes.
+- Versatility: CIDs are meant to be able to represent values of any format with any cryptographic hash.
+- Avoid Lock-in: CIDs prevent lock-in to old, potentially-outdated decisions.
+- Upgradability: CIDs encode a version to ensure the CID format itself can evolve.
+
+## Versions
+
+### CIDv0
+
+CIDv0 is a backwards-compatible version, where:
+- the `multibase` of the string representation is always `base58btc` and implicit (not written)
+- the `multicodec` is always `dag-pb` and implicit (not written)
+- the `cid-version` is always `cidv0` and implicit (not written)
+- the `multihash` is written as is but is always a full (length 32) sha256 hash.
+
+```text
+cidv0 ::= <multihash-content-address>
+```
+
+### CIDv1
+
+See the section: [How does it work?](#how-does-it-work)
+
+```text
+<cidv1> ::= <multibase-prefix><multicodec-cidv1><multicodec-content-type><multihash-content-address>
+```
+
+## Decoding Algorithm
+
+To decode a CID, follow the following algorithm:
+
+1. If it's a string (ASCII/UTF-8):
+  * If it is 46 characters long and starts with `Qm...`, it's a CIDv0. Decode it as base58btc and continue to step 2.
+  * Otherwise, decode it according to the multibase spec and:
+    * If the first decoded byte is 0x12, return an error. CIDv0 CIDs may not be multibase encoded and there will be no CIDv18 (0x12 = 18) to prevent ambiguity with decoded CIDv0s.
+    * Otherwise, you now have a binary CID. Continue to step 2.
+2. Given a (binary) CID (`cid`):
+   * If it's 34 bytes long with the leading bytes `[0x12, 0x20, ...]`, it's a CIDv0.
+     * The CID's multihash is `cid`.
+     * The CID's multicodec is DagProtobuf
+     * The CID's version is 0.
+   * Otherwise, let `N` be the first varint in `cid`. This is the CID's version.
+     * If `N == 0x01` (CIDv1):
+       * The CID's multicodec is the second varint in `cid`
+       * The CID's multihash is the rest of the `cid` (after the second varint).
+       * The CID's version is 1.
+     * If `N == 0x02` (CIDv2), or `N == 0x03` (CIDv3), the CID version is reserved.
+     * If `N` is equal to some other multicodec, the CID is malformed.
+
+# Appendices
+
+:::warning
+These sections provide additional context. This is not part of specification,
+and is provided here only for extra context.
+:::
+
+## Implementations
+
+- [go-cid](https://github.com/ipfs/go-cid)
+- [java-cid](https://github.com/ipld/java-cid)
+- [js-multiformats](https://github.com/multiformats/js-multiformats)
+- [rust-cid](https://github.com/multiformats/rust-cid)
+- [py-multiformats-cid](https://github.com/pinnaculum/py-multiformats-cid)
+- [elixir-cid](https://github.com/nocursor/ex-cid)
+- [dart_cid](https://github.com/dwyl/dart_cid)
+- [zig_cid](https://github.com/zen-eth/multiformats-zig)
+- [Add yours today!](https://github.com/multiformats/cid/edit/master/README.md)
+
+## FAQ
+
+> **Q. I have questions on multicodec, multibase, or multihash.**
+
+Please check their repositories: [multicodec](https://github.com/multiformats/multicodec), [multibase](https://github.com/multiformats/multibase), [multihash](https://github.com/multiformats/multihash).
+
+> **Q. Why does CID exist?**
+
+We were using base58btc encoded multihashes in IPFS, and then we needed to switch formats to IPLD. 
+We struggled with lots of problems of addressing data with different formats until we created CIDs. 
+You can read the history of this format here: https://github.com/ipfs/specs/issues/130
+
+> **Q. Is the use of multicodec similar to file extensions?**
+
+Yes, kind of! like a file extension, the multicodec identifier establishes the format of the data. 
+Unlike file extensions, these are in the middle of the identifier and not meant to be changed by users.
+There is also a short table of supported formats.
+
+> **Q. What formats (multicodec codes) does CID support?**
+
+We are figuring this out at this time. 
+It will likely be a subset of [multicodecs](https://github.com/multiformats/multicodec/blob/master/table.csv) for secure distributed systems. 
+So far, we want to address IPFS's UnixFS and raw blocks ([`dag-pb`](https://ipld.io/specs/codecs/dag-pb/spec/), [`raw`](https://www.iana.org/assignments/media-types/application/vnd.ipld.raw)), IPNS's [`libp2p-key`](https://github.com/libp2p/specs/blob/master/RFC/0001-text-peerid-cid.md), and IPLD's [`dag-json`](https://ipld.io/specs/codecs/dag-json/spec/)/[`dag-cbor`](https://ipld.io/specs/codecs/dag-cbor/spec/) formats.
+
+> **Q. What is the process for updating CID specification (e.g., adding a new version)?**
+
+CIDs are a well established standard. 
+IPFS uses CIDs for content-addressing and IPNS.
+Making changes to such key protocol requires a careful review which should include feedback from implementers and stakeholders across ecosystem.
+
+Due to this, changes to CID specification MUST be submitted as an improvement proposal to [ipfs/specs](https://github.com/ipfs/specs/tree/main/IPIP) repository (PR with [IPIP document](https://github.com/ipfs/specs/blob/main/IPIP/0000-template.md)), and follow the IPIP process described there. 
+
+## Historical Design Decisions
+
+You can read an [in-depth discussion on why this format was needed in IPFS](https://github.com/ipfs/specs/issues/130).

--- a/src/data-formats/cid.md
+++ b/src/data-formats/cid.md
@@ -26,17 +26,17 @@ tags: ['data-formats']
 order: 1
 ---
 
-**CID** is a format for referencing content in distributed information systems, like [IPFS](https://ipfs.io). 
-It leverages [content addressing](https://en.wikipedia.org/wiki/Content-addressable_storage), 
-[cryptographic hashing](https://simple.wikipedia.org/wiki/Cryptographic_hash_function), and 
-[self-describing formats](https://github.com/multiformats/multiformats). 
-It is the core identifier used by [IPFS](https://ipfs.io) and [IPLD](https://ipld.io). 
+**CID** is a format for referencing content in distributed information systems, like [IPFS](https://ipfs.io).
+It leverages [content addressing](https://en.wikipedia.org/wiki/Content-addressable_storage),
+[cryptographic hashing](https://simple.wikipedia.org/wiki/Cryptographic_hash_function), and
+[self-describing formats](https://github.com/multiformats/multiformats).
+It is the core identifier used by [IPFS](https://ipfs.io) and [IPLD](https://ipld.io).
 It uses a [multicodec](https://github.com/multiformats/multicodec) to indicate its version, making it fully self describing.
 
 ## What is it?
 
-A CID is a self-describing content-addressed identifier. 
-It uses cryptographic hashes to achieve content addressing. It uses several 
+A CID is a self-describing content-addressed identifier.
+It uses cryptographic hashes to achieve content addressing. It uses several
 [multiformats](https://github.com/multiformats/multiformats) to achieve flexible self-description, namely:
 
 1. [multihash](https://github.com/multiformats/multihash) to hash content addressed, and
@@ -50,7 +50,7 @@ Concretely, it's a *typed* content address: a tuple of `(content-type, content-a
 
 Current version: CIDv1.
 
-CIDv1 is a **binary** format composed of [unsigned varints](https://github.com/multiformats/unsigned-varint) 
+CIDv1 is a **binary** format composed of [unsigned varints](https://github.com/multiformats/unsigned-varint)
 prefixing a hash digest to form a self-describing "content address":
 
 ```text
@@ -67,8 +67,8 @@ Where
 
 ## Variant - Stringified Form
 
-Since CIDs have many applications outside of binary-only contexts, a given CID may need to be base-encoded multiple ways for different consumers or for different transports. 
-In such applications, CIDs are often expressed as a Unicode *string* rather than a bytestring, which adds a single code-point prefix. 
+Since CIDs have many applications outside of binary-only contexts, a given CID may need to be base-encoded multiple ways for different consumers or for different transports.
+In such applications, CIDs are often expressed as a Unicode *string* rather than a bytestring, which adds a single code-point prefix.
 In these contexts, then, the full string form is:
 
 ```text
@@ -81,7 +81,7 @@ Where
 
 ## Variant - Human-Readable Form
 
-It is often advantageous to translate a CID, which is already modular and self-describing, into a *human-readable* expansion of its self-describing parts, for purposes such as debugging, unit testing, and documentation. 
+It is often advantageous to translate a CID, which is already modular and self-describing, into a *human-readable* expansion of its self-describing parts, for purposes such as debugging, unit testing, and documentation.
 We can easily transform a Stringified CID to a "Human-Readable CID" by translating and segmenting its constituent parts as follows:
 
 ```text
@@ -141,22 +141,22 @@ See the section: [How does it work?](#how-does-it-work)
 To decode a CID, follow the following algorithm:
 
 1. If it's a string (ASCII/UTF-8):
-  * If it is 46 characters long and starts with `Qm...`, it's a CIDv0. Decode it as base58btc and continue to step 2.
-  * Otherwise, decode it according to the multibase spec and:
-    * If the first decoded byte is 0x12, return an error. CIDv0 CIDs may not be multibase encoded and there will be no CIDv18 (0x12 = 18) to prevent ambiguity with decoded CIDv0s.
-    * Otherwise, you now have a binary CID. Continue to step 2.
+* If it is 46 characters long and starts with `Qm...`, it's a CIDv0. Decode it as base58btc and continue to step 2.
+* Otherwise, decode it according to the multibase spec and:
+  * If the first decoded byte is 0x12, return an error. CIDv0 CIDs may not be multibase encoded and there will be no CIDv18 (0x12 = 18) to prevent ambiguity with decoded CIDv0s.
+  * Otherwise, you now have a binary CID. Continue to step 2.
 2. Given a (binary) CID (`cid`):
-   * If it's 34 bytes long with the leading bytes `[0x12, 0x20, ...]`, it's a CIDv0.
-     * The CID's multihash is `cid`.
-     * The CID's multicodec is DagProtobuf
-     * The CID's version is 0.
-   * Otherwise, let `N` be the first varint in `cid`. This is the CID's version.
-     * If `N == 0x01` (CIDv1):
-       * The CID's multicodec is the second varint in `cid`
-       * The CID's multihash is the rest of the `cid` (after the second varint).
-       * The CID's version is 1.
-     * If `N == 0x02` (CIDv2), or `N == 0x03` (CIDv3), the CID version is reserved.
-     * If `N` is equal to some other multicodec, the CID is malformed.
+* If it's 34 bytes long with the leading bytes `[0x12, 0x20, ...]`, it's a CIDv0.
+  * The CID's multihash is `cid`.
+  * The CID's multicodec is DagProtobuf
+  * The CID's version is 0.
+* Otherwise, let `N` be the first varint in `cid`. This is the CID's version.
+  * If `N == 0x01` (CIDv1):
+    * The CID's multicodec is the second varint in `cid`
+    * The CID's multihash is the rest of the `cid` (after the second varint).
+    * The CID's version is 1.
+  * If `N == 0x02` (CIDv2), or `N == 0x03` (CIDv3), the CID version is reserved.
+  * If `N` is equal to some other multicodec, the CID is malformed.
 
 # Appendices
 
@@ -185,29 +185,29 @@ Please check their repositories: [multicodec](https://github.com/multiformats/mu
 
 > **Q. Why does CID exist?**
 
-We were using base58btc encoded multihashes in IPFS, and then we needed to switch formats to IPLD. 
-We struggled with lots of problems of addressing data with different formats until we created CIDs. 
+We were using base58btc encoded multihashes in IPFS, and then we needed to switch formats to IPLD.
+We struggled with lots of problems of addressing data with different formats until we created CIDs.
 You can read the history of this format here: https://github.com/ipfs/specs/issues/130
 
 > **Q. Is the use of multicodec similar to file extensions?**
 
-Yes, kind of! like a file extension, the multicodec identifier establishes the format of the data. 
+Yes, kind of! like a file extension, the multicodec identifier establishes the format of the data.
 Unlike file extensions, these are in the middle of the identifier and not meant to be changed by users.
 There is also a short table of supported formats.
 
 > **Q. What formats (multicodec codes) does CID support?**
 
-We are figuring this out at this time. 
-It will likely be a subset of [multicodecs](https://github.com/multiformats/multicodec/blob/master/table.csv) for secure distributed systems. 
+We are figuring this out at this time.
+It will likely be a subset of [multicodecs](https://github.com/multiformats/multicodec/blob/master/table.csv) for secure distributed systems.
 So far, we want to address IPFS's UnixFS and raw blocks ([`dag-pb`](https://ipld.io/specs/codecs/dag-pb/spec/), [`raw`](https://www.iana.org/assignments/media-types/application/vnd.ipld.raw)), IPNS's [`libp2p-key`](https://github.com/libp2p/specs/blob/master/RFC/0001-text-peerid-cid.md), and IPLD's [`dag-json`](https://ipld.io/specs/codecs/dag-json/spec/)/[`dag-cbor`](https://ipld.io/specs/codecs/dag-cbor/spec/) formats.
 
 > **Q. What is the process for updating CID specification (e.g., adding a new version)?**
 
-CIDs are a well established standard. 
+CIDs are a well established standard.
 IPFS uses CIDs for content-addressing and IPNS.
 Making changes to such key protocol requires a careful review which should include feedback from implementers and stakeholders across ecosystem.
 
-Due to this, changes to CID specification MUST be submitted as an improvement proposal to [ipfs/specs](https://github.com/ipfs/specs/tree/main/IPIP) repository (PR with [IPIP document](https://github.com/ipfs/specs/blob/main/IPIP/0000-template.md)), and follow the IPIP process described there. 
+Due to this, changes to CID specification MUST be submitted as an improvement proposal to [ipfs/specs](https://github.com/ipfs/specs/tree/main/IPIP) repository (PR with [IPIP document](https://github.com/ipfs/specs/blob/main/IPIP/0000-template.md)), and follow the IPIP process described there.
 
 ## Historical Design Decisions
 

--- a/src/data-formats/cid.md
+++ b/src/data-formats/cid.md
@@ -21,6 +21,19 @@ editors:
 former_editors:
   - name: Juan Benet
     github: jbenet
+thanks:
+  - name: Steven Allen
+    github: Stebalien
+  - name: Rod Vagg
+    github: rvagg
+  - name: bumblefudge
+    github: bumblefudge
+  - name: Volker Mische
+    github: vmx
+  - name: Joel Thorstensson
+    github: oed
+  - name: Oli Evans
+    github: olizilla
 
 tags: ['data-formats']
 order: 1

--- a/src/data-formats/cid.md
+++ b/src/data-formats/cid.md
@@ -145,7 +145,7 @@ To decode a CID, follow the following algorithm:
 * Otherwise, decode it according to the multibase spec and:
   * If the first decoded byte is 0x12, return an error. CIDv0 CIDs may not be multibase encoded and there will be no CIDv18 (0x12 = 18) to prevent ambiguity with decoded CIDv0s.
   * Otherwise, you now have a binary CID. Continue to step 2.
-2. Given a (binary) CID (`cid`):
+1. Given a (binary) CID (`cid`):
 * If it's 34 bytes long with the leading bytes `[0x12, 0x20, ...]`, it's a CIDv0.
   * The CID's multihash is `cid`.
   * The CID's multicodec is DagProtobuf

--- a/src/data-formats/cid.md
+++ b/src/data-formats/cid.md
@@ -133,7 +133,7 @@ cidv0 ::= <multihash-content-address>
 See the section: [How does it work?](#how-does-it-work)
 
 ```text
-<cidv1> ::= <multibase-prefix><multicodec-cidv1><multicodec-content-type><multihash-content-address>
+<cidv1> ::= <multicodec-cidv1><multicodec-content-type><multihash-content-address>
 ```
 
 ## Decoding Algorithm

--- a/src/data-formats/cid.md
+++ b/src/data-formats/cid.md
@@ -196,9 +196,9 @@ and is provided here only for extra context.
 
 ## FAQ
 
-> **Q. I have questions on multicodec, multibase, or multihash.**
+> **Q. I have questions on multicodec, multibase, multihash, or unsigned-varint.**
 
-Please check their repositories: [multicodec](https://github.com/multiformats/multicodec), [multibase](https://github.com/multiformats/multibase), [multihash](https://github.com/multiformats/multihash).
+Please check their repositories: [multicodec](https://github.com/multiformats/multicodec), [multibase](https://github.com/multiformats/multibase), [multihash](https://github.com/multiformats/multihash), [unsigned-varint](https://github.com/multiformats/unsigned-varint).
 
 > **Q. Why does CID exist?**
 

--- a/src/data-formats/cid.md
+++ b/src/data-formats/cid.md
@@ -2,7 +2,7 @@
 title: CID (Content IDentifier)
 description: >
     Self-describing content-addressed identifiers for distributed systems
-date: 2026-06-15
+date: 2026-06-26
 maturity: permanent
 editors:
   - name: Marcin Rataj
@@ -167,12 +167,10 @@ To decode a binary CID `bytes`:
 
 To decode a CID string (ASCII or UTF-8):
 
-1. If the string is 46 characters long and begins with `Qm`:
-   1. Decode it as `base58btc` to get `bytes`.
-   2. Decode `bytes` as a binary CID (above) and return the result; it validates as a CIDv0.
-2. Otherwise, decode the string by its [multibase](https://github.com/multiformats/multibase) prefix to get `bytes`.
-3. If the first byte of `bytes` is `0x12`, a decoder MUST reject the input: a CIDv0 is never multibase-encoded, and `0x12` equals 18, a value reserved so that no CIDv18 can be confused with a base-decoded CIDv0.
-4. Decode `bytes` as a binary CID (above) and return the result.
+1. Convert the string to binary `bytes`:
+   - If it is 46 characters long and begins with `Qm`, it is a CIDv0; decode it as `base58btc`.
+   - Otherwise, decode it by its [multibase](https://github.com/multiformats/multibase) prefix.
+2. Decode `bytes` as a binary CID (above) and return the result.
 
 # Appendices
 

--- a/src/data-formats/cid.md
+++ b/src/data-formats/cid.md
@@ -2,7 +2,7 @@
 title: CID (Content IDentifier)
 description: >
     Self-describing content-addressed identifiers for distributed systems
-date: 2026-03-12
+date: 2026-06-15
 maturity: permanent
 editors:
   - name: Marcin Rataj
@@ -154,24 +154,47 @@ See the section: [How does it work?](#how-does-it-work)
 
 ## Decoding Algorithm
 
-To decode a CID, follow this algorithm:
+The binary fields of a CID are [unsigned varints](https://github.com/multiformats/unsigned-varint).
+Two rules hold for every CID:
 
-1. If it's a string (ASCII/UTF-8):
-   * If it is 46 characters long and starts with `Qm`, it's a CIDv0. Decode it as base58btc and continue to step 2.
-   * Otherwise, decode it according to the multibase spec and:
-     * If the first decoded byte is `0x12`, return an error. CIDv0 CIDs may not be multibase encoded and there will be no CIDv18 (`0x12` = 18) to prevent ambiguity with decoded CIDv0s.
-     * Otherwise, you now have a binary CID. Continue to step 2.
-2. Given a (binary) CID (`cid`):
-   * If the first two bytes are `[0x12, 0x20]` (the `sha2-256` multihash function code followed by digest length 32), it's a CIDv0.
-     * The CID's multihash is `cid` (34 bytes: 2-byte prefix + 32-byte digest).
-     * The CID's multicodec is `dag-pb` (`0x70`), implicit.
-     * The CID's version is 0.
-   * Otherwise, read the first varint in `cid`. This is the CID's version.
-     * If `0x01` (CIDv1):
-       * The CID's multicodec is the second varint in `cid`.
-       * The CID's multihash is the rest of `cid` (after the second varint).
-       * The CID's version is 1.
-     * Otherwise, the CID is malformed.
+- each varint MUST be minimally encoded, and a decoder MUST reject any overlong (non-minimal) varint;
+- a decoder MUST reject any bytes left over after the multihash.
+
+A binary CID has one of two shapes, told apart by its leading bytes:
+
+| Leading bytes | Shape |
+| --- | --- |
+| `0x01` | a **CIDv1**, where this first varint is the version field |
+| `0x12 0x20` | a bare 34-byte `sha2-256` multihash: a **CIDv0** |
+| anything else | not a CID; a decoder MUST reject it |
+
+A CIDv0 is identified by the two-byte prefix `0x12 0x20`, not by the leading byte `0x12` alone: `0x12` is the `sha2-256` multihash code and `0x20` is its digest length, 32. A CIDv0 has no version field.
+
+### Decoding a binary CID
+
+To decode a binary CID `bytes`:
+
+1. If `bytes` is exactly 34 bytes long and begins with `0x12 0x20`, it is a **CIDv0**, a bare `sha2-256` multihash (`cidv0 ::= <multihash-content-address>`):
+   1. The 34 bytes are `0x12` (the `sha2-256` code), `0x20` (the digest length, 32), and a 32-byte digest.
+   2. The content type is implicitly `dag-pb` (`0x70`) and is not encoded.
+2. Otherwise, read the leading varint of `bytes`.
+3. If the leading varint is `0x01`, it is a **CIDv1** (`<cidv1> ::= <multicodec-cidv1><multicodec-content-type><multihash-content-address>`):
+   1. The `<multicodec-cidv1>` version field is the `0x01` just read.
+   2. Read the next varint as the `<multicodec-content-type>`, which types the content.
+   3. Read the [`<multihash-content-address>`](https://github.com/multiformats/multihash) that follows, structured as `<hash-code><digest-length><digest>`.
+   4. The `<digest-length>` MUST consume the remaining bytes exactly; a decoder MUST reject a truncated digest or any trailing bytes.
+4. Otherwise, a decoder MUST reject `bytes`. No other leading value is a CID. In particular, reject a leading `0x12` that is not the `0x12 0x20` prefix of a 34-byte input, and reject `0x00`, `0x02` (reserved for the never-deployed CIDv2), and `0x03` (reserved for the never-deployed CIDv3).
+
+### Decoding a CID string
+
+To decode a CID string (ASCII or UTF-8):
+
+1. If the string is 46 characters long and begins with `Qm`:
+   1. Decode it as `base58btc` to get `bytes`.
+   2. Decode `bytes` as a binary CID (above) and return the result; it validates as a CIDv0.
+2. Otherwise, decode the string by its [multibase](https://github.com/multiformats/multibase) prefix to get `bytes`.
+3. If the first byte of `bytes` is `0x12`, a decoder MUST reject the input: a CIDv0 is never multibase-encoded, and `0x12` equals 18, a value reserved so that no CIDv18 can be confused with a base-decoded CIDv0.
+4. Decode `bytes` as a binary CID (above) and return the result.
 
 # Appendices
 

--- a/src/data-formats/cid.md
+++ b/src/data-formats/cid.md
@@ -95,31 +95,6 @@ Where
 
 IPFS implementations SHOULD support at minimum `base58btc` (`z`), `base32` (`b`), `base16` (`f`), and `base36` (`k`, for ed25519 keys in [IPNS Records](https://specs.ipfs.tech/ipns/ipns-record/)).
 
-## Variant - Human-Readable Form
-
-It is often advantageous to translate a CID, which is already modular and self-describing, into a *human-readable* expansion of its self-describing parts, for purposes such as debugging, unit testing, and documentation.
-We can easily transform a Stringified CID to a "Human-Readable CID" by translating and segmenting its constituent parts as follows:
-
-```text
-<hr-cid> ::= <hr-mbc> "-" <hr-cid-mc> "-" <hr-mc> "-" <hr-mh>
-```
-Where each sub-component is replaced with its own human-readable form from the relevant registry:
-
-- `<hr-mbc>` is the name of the multibase code (eg `z`--> `base58btc`)
-- `<hr-cid-mc>` is the name of the multicodec for the version of CID used (eg `0x01` --> `cidv1`)
-- `<hr-mc>` is the name of the multicodec code (eg `0x51` --> `cbor`)
-- `<hr-mh>` is the name of the multihash code (eg `sha2-256-256`) followed by a final dash and the hash itself `-abcdef0123456789...`)
-
-For example:
-
-```text
-# example CID
-zb2rhe5P4gXftAwvA4eXQ5HJwsER2owDyS9sKaQRRVQPn93bA
-# corresponding human readable CID
-base58btc - cidv1 - raw - sha2-256-256-6e6ff7950a36187a801613426e858dce686cd7d7e3c0fc42ee0330072d245c95
-```
-See: https://cid.ipfs.io/#zb2rhe5P4gXftAwvA4eXQ5HJwsER2owDyS9sKaQRRVQPn93bA
-
 ## Design Considerations
 
 CIDs design takes into account many difficult tradeoffs encountered while building [IPFS](https://ipfs.tech). These are mostly coming from the multiformats project.
@@ -252,3 +227,34 @@ Due to this, changes to CID specification MUST be submitted as an improvement pr
 ## Historical Design Decisions
 
 You can read an [in-depth discussion on why this format was needed in IPFS](https://github.com/ipfs/specs/issues/130) and the [original CIDv1 proposal](https://github.com/multiformats/cid/blob/f638ca68390758f0d4c7f90ac843091d3973cd02/original-rfc.md).
+
+## Human-Readable Form
+
+This is design guidance for tools that present a human-readable CID inspector to a user, such as a debugger, a block explorer, or the diagnostic UI at https://cid.ipfs.tech.
+It is not a wire format: nothing produces or parses it, and it carries no information beyond what the CID already encodes.
+
+When such a UI needs to show what a CID contains, it can expand the already self-describing CID into a labelled listing of its parts:
+
+```text
+<hr-cid> ::= <hr-mbc> "-" <hr-cid-mc> "-" <hr-mc> "-" <hr-mh>
+```
+
+Where each sub-component is the name of its code in the relevant multiformats registry:
+
+- `<hr-mbc>` is the multibase code name (eg `b` -> `base32`)
+- `<hr-cid-mc>` is the CID version multicodec name (eg `0x01` -> `cidv1`)
+- `<hr-mc>` is the content-type multicodec name (eg `0x55` -> `raw`)
+- `<hr-mh>` is the multihash code name and digest length (eg `sha2-256-256`), then a final dash and the hex digest
+
+For example, the CIDv1 for the raw bytes `hello`:
+
+```text
+# example CID
+bafkreibm6jg3ux5qumhcn2b3flc3tyu6dmlb4xa7u5bf44yegnrjhc4yeq
+# corresponding human readable CID
+base32 - cidv1 - raw - sha2-256-256-2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824
+```
+
+These names come from the multiformats registries and are provisional labels for human eyes only; only the numeric codes are stable.
+A UI should show the codes next to the names, and no consumer should rely on a name staying the same.
+See: https://cid.ipfs.tech/#bafkreibm6jg3ux5qumhcn2b3flc3tyu6dmlb4xa7u5bf44yegnrjhc4yeq

--- a/src/data-formats/cid.md
+++ b/src/data-formats/cid.md
@@ -44,18 +44,19 @@ It leverages [content addressing](https://en.wikipedia.org/wiki/Content-addressa
 [cryptographic hashing](https://simple.wikipedia.org/wiki/Cryptographic_hash_function), and
 [self-describing formats](https://github.com/multiformats/multiformats).
 It is the core identifier used by [IPFS](https://ipfs.tech) and [IPLD](https://ipld.io).
-It uses a [multicodec](https://github.com/multiformats/multicodec) to indicate its version, making it fully self describing.
+It uses a [multicodec](https://github.com/multiformats/multicodec) to indicate its version, making it fully self-describing.
 
 ## What is it?
 
 A CID is a self-describing content-addressed identifier.
-It uses cryptographic hashes to achieve content addressing. It uses several
-[multiformats](https://github.com/multiformats/multiformats) to achieve flexible self-description, namely:
+It uses cryptographic hashes for content addressing and several
+[multiformats](https://github.com/multiformats/multiformats) for flexible self-description, namely:
 
-1. [multihash](https://github.com/multiformats/multihash) for content-addressed hashing, and
-2. [multicodec](https://github.com/multiformats/multicodec) to type that addressed content,
-to form a binary self-contained identifier, and optionally also
-3. [multibase](https://github.com/multiformats/multibase) to encode that binary CID as a string.
+1. [multihash](https://github.com/multiformats/multihash) for content-addressed hashing,
+2. [multicodec](https://github.com/multiformats/multicodec) to type that addressed content, and
+3. optionally, [multibase](https://github.com/multiformats/multibase) to encode the binary CID as a string.
+
+The first two form a self-contained binary identifier; the third is added only when the CID is written as text.
 
 Concretely, it's a *typed* content address: a tuple of `(content-type, content-address)`.
 
@@ -67,9 +68,11 @@ CIDv1 is a **binary** format composed of [unsigned varints](https://github.com/m
 prefixing a hash digest to form a self-describing "content address":
 
 ```text
-<cidv1> ::= <CIDv1-multicodec><content-type-multicodec><content-multihash>
-# or, expanded:
-<cidv1> ::= <`0x01`, the code for `CIDv1`><another code from `ipld` entries in multicodec table that signals content type of data being addressed><multihash of addressed data>
+<cidv1> ::= <multicodec-cidv1><multicodec-content-type><multihash-content-address>
+
+# example: a CIDv1 addressing the raw bytes "hello", in hex
+01 55 12 20 2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824
+# 01: cidv1 | 55: raw | 12 20: sha2-256, 32 bytes | 2cf2...: sha2-256 digest of "hello"
 ```
 
 Where
@@ -78,15 +81,15 @@ Where
 - `<multicodec-content-type>` is a [multicodec](https://github.com/multiformats/multicodec) code representing the content type or format of the data being addressed.
 - `<multihash-content-address>` is a [multihash](https://github.com/multiformats/multihash) value, which uses a registry of hash function abbreviations to prefix a cryptographic hash of the content being addressed, thus making it self-describing.
 
-## Variant - Stringified Form
+## Stringified Form
 
-Since CIDs have many applications outside of binary-only contexts, a given CID may need to be base-encoded for different consumers or transports.
+Since CIDs have many applications outside binary-only contexts, a CID may need to be base-encoded for different consumers or transports.
 In such applications, CIDs are expressed as a Unicode *string* with a [multibase](https://github.com/multiformats/multibase) prefix.
-The multibase prefix identifies the string encoding but is not part of the CID itself -- the same binary CID may be represented in different bases depending on context and needs such as string length and case-sensitivity.
+The multibase prefix identifies the string encoding but is not part of the CID itself; the same binary CID can appear in different bases depending on context and needs such as string length and case-sensitivity.
 The full string form is:
 
 ```text
-<cidv1-str> ::= <multibase-prefix><multibase-encoding(<CIDv1-multicodec><multicodec><multihash>)>
+<cidv1-str> ::= <multibase-prefix><multibase-encoding(<multicodec-cidv1><multicodec-content-type><multihash-content-address>)>
 ```
 
 Where
@@ -97,9 +100,9 @@ IPFS implementations SHOULD support at minimum `base58btc` (`z`), `base32` (`b`)
 
 ## Design Considerations
 
-CIDs design takes into account many difficult tradeoffs encountered while building [IPFS](https://ipfs.tech). These are mostly coming from the multiformats project.
+The design of CIDs takes into account many difficult tradeoffs encountered while building [IPFS](https://ipfs.tech). Most of these come from the multiformats project.
 
-- Compactness: CIDs are binary in nature to ensure these are as compact as possible, as they're meant to be part of longer path identifiers or URIs.
+- Compactness: CIDs are binary to keep them as compact as possible, since they're meant to be part of longer path identifiers or URIs.
 - Transport friendliness (or "copy-pastability"): CIDs are encoded with multibase to allow choosing the best base for transporting. For example, CIDs can be encoded into base58btc to yield shorter and easily-copy-pastable hashes.
 - Versatility: CIDs are meant to be able to represent values of any format with any cryptographic hash.
 - Avoid Lock-in: CIDs prevent lock-in to old, potentially-outdated decisions.
@@ -209,7 +212,7 @@ The history of this format is documented at: https://github.com/ipfs/specs/issue
 > **Q. Is the use of multicodec similar to file extensions?**
 
 Yes. Like a file extension, the multicodec in a CID tells consumers how to interpret the bytes.
-And just like file extensions, most users will never change it, but it is technically possible to swap the codec to change how the same bytes behind a CID are parsed.
+And just like file extensions, most users will never change it, but you can swap the codec to change how the same bytes are parsed.
 
 > **Q. What formats (multicodec codes) does CID support?**
 
@@ -220,9 +223,9 @@ In practice, IPFS primarily uses [`dag-pb`](https://web.archive.org/web/20260305
 
 CIDs are a well established standard.
 IPFS uses CIDs for content-addressing and IPNS.
-Making changes to such key protocol requires a careful review which should include feedback from implementers and stakeholders across ecosystem.
+Changing such a core protocol requires careful review, including feedback from implementers and stakeholders across the ecosystem.
 
-Due to this, changes to CID specification MUST be submitted as an improvement proposal to [ipfs/specs](https://github.com/ipfs/specs/tree/main/IPIP) repository (PR with [IPIP document](https://github.com/ipfs/specs/blob/main/IPIP/0000-template.md)), and follow the IPIP process described there.
+For this reason, changes to the CID specification MUST be submitted as an improvement proposal to [ipfs/specs](https://github.com/ipfs/specs/tree/main/IPIP) repository (PR with [IPIP document](https://github.com/ipfs/specs/blob/main/ipip-template.md)), and follow the IPIP process described there.
 
 ## Historical Design Decisions
 

--- a/src/unixfs.md
+++ b/src/unixfs.md
@@ -66,7 +66,7 @@ thanks:
     github: bumblefudge
 
 tags: ['data-formats']
-order: 1
+order: 2
 ---
 
 # Node Types


### PR DESCRIPTION

TLDR from @lidel: 

> 
> This PR brings CID spec that lived in [multiformats/cid](https://github.com/multiformats/cid/blob/e5e2b96981f4057f715ddc2f78d31bdf296ea616/README.md), outside the IPFS spec site, with dated examples and decoding prose loose enough that implementations diverged on edge cases.
> 
> The modernized port of that README into `ipfs/specs` to clarify use of CID in IPFS systems:
> 
> - tightened phrasing and an unambiguous decoding algorithm
> - modern CIDv1 examples (`base32`, `bafkrei…`) in place of the old base58btc ones
> - decoding rules cross-checked against [go-cid](https://github.com/ipfs/go-cid), [js-multiformats](https://github.com/multiformats/js-multiformats), and [rust-cid](https://github.com/multiformats/rust-cid)