### PR TITLE
delegated routing: resolve DNSADDR addresses before filtering

### DIFF
--- a/src/routing/http-routing-v1.md
+++ b/src/routing/http-routing-v1.md
@@ -4,7 +4,7 @@ description: >
   Delegated routing is a mechanism for IPFS implementations to use for offloading
   content routing, peer routing and naming to another process/server. This specification describes
   an HTTP API for delegated routing of content, peers, and IPNS.
-date: 2025-12-17
+date: 2026-07-29
 maturity: reliable
 editors:
   - name: Marcin Rataj
@@ -102,7 +102,7 @@ Optional `?filter-addrs` to apply Network Address Filtering from [IPIP-484](http
 - If both positive and negative filters are provided, the address must pass all negative filters and at least one positive filter to be included.
 - If there are no multiaddrs that match the passed transports, the provider is omitted from the response.
 - Filtering is case-insensitive.
-- Where a peer reports a [DNSADDR] address, it should be fully resolved before filtering is applied to the final address set.
+- Where a peer reports a [DNSADDR] address, it SHOULD be fully resolved before filtering is applied to the final address set. The original `/dnsaddr` address SHOULD be kept in that set, so that a client asking for it (e.g. `?filter-addrs=dnsaddr`) still gets it back.
 
 ##### `filter-protocols` (providers request query parameter)
 

--- a/src/routing/http-routing-v1.md
+++ b/src/routing/http-routing-v1.md
@@ -102,6 +102,7 @@ Optional `?filter-addrs` to apply Network Address Filtering from [IPIP-484](http
 - If both positive and negative filters are provided, the address must pass all negative filters and at least one positive filter to be included.
 - If there are no multiaddrs that match the passed transports, the provider is omitted from the response.
 - Filtering is case-insensitive.
+- Where a peer reports a [DNSADDR] address, it should be fully resolved before filtering is applied to the final address set.
 
 ##### `filter-protocols` (providers request query parameter)
 
@@ -468,6 +469,7 @@ libp2p protocol.
 
 [multibase]: https://github.com/multiformats/multibase
 [CIDv1]: https://github.com/multiformats/cid#cidv1
+[DNSADDR]: https://github.com/multiformats/multiaddr/blob/master/protocols/DNSADDR.md
 [multiaddr]: https://github.com/multiformats/multiaddr#specification
 [peer-id]: https://github.com/libp2p/specs/blob/master/peer-ids/peer-ids.md
 [peer-id-representation]: https://github.com/libp2p/specs/blob/master/peer-ids/peer-ids.md#string-representation


### PR DESCRIPTION
Delegated HTTP Routing clients can specify address filters to limit returned providers to ones that listen on transports supported by the client.

`DNSADDR` addresses are a special case in that they can resolve to multiple addresses that may contain tuples from the filter, and the starting address is not likely to contain them.

This IPIP suggests adding a line to the spec that reminds the implementer they should resolve `DNSADDR` addresses to the final set before applying any address filters as otherwise valid, dialable providers would be omitted from the response.