### PR TITLE
spec: ipfs:// and ipns:// URI schemes

### DIFF
--- a/src/ipfs-uri.md
+++ b/src/ipfs-uri.md
@@ -4,7 +4,7 @@ description: >
   The ipfs:// URI scheme for addressing immutable, content-addressed data by
   CID, defined for interoperability with web browsers.
 date: 2026-08-03
-maturity: draft
+maturity: reliable
 editors:
   - name: Marcin Rataj
     github: lidel

--- a/src/ipfs-uri.md
+++ b/src/ipfs-uri.md
@@ -3,7 +3,7 @@ title: IPFS URI (ipfs://)
 description: >
   The ipfs:// URI scheme for addressing immutable, content-addressed data by
   CID, defined for interoperability with web browsers.
-date: 2026-08-02
+date: 2026-08-03
 maturity: draft
 editors:
   - name: Marcin Rataj
@@ -197,6 +197,10 @@ behavior, and nothing needs to: the codec in the content root does.
   following it moves the traversal into a different document.
 - `raw` is opaque bytes with no links to follow, so a non-empty path has nowhere to go.
 
+Other codecs follow the same rule: a resolver walks `{path}` only as far as the codec defines
+links, so a codec with no links, or one the resolver does not recognize, leaves a non-empty path
+unresolvable.
+
 This applies at every step, not only the first. Each link the traversal follows carries its own CID
 with its own codec, so the rules can change partway down a path: a `dag-cbor` root can link to a
 `dag-pb` node, after which the remaining segments are UnixFS names. Path Gateway
@@ -223,8 +227,9 @@ rests on that gateway rather than on the URI.
 A native `ipfs://` implementation SHOULD resolve content paths with the same semantics as a
 Path Gateway, so that the same URI resolves consistently whether it is opened by a native handler
 or handed to a gateway. In a browser-like context, a native implementation SHOULD also mirror the
-origin isolation that a Subdomain Gateway provides, giving each content root its own origin (see
-[Origin](#origin)).
+origin isolation that a Subdomain Gateway provides, giving each content root its own origin,
+derived from the scheme and that root alone. [Origin](#origin) describes the two serializations
+known to work.
 
 ## Notes for implementers
 
@@ -234,8 +239,8 @@ new requirements.
 ### Reading `ipfs://` as a WHATWG URL
 
 The `//` is what makes the content root an authority. Neither `ipfs` nor `ipns` is a
-[special scheme](https://url.spec.whatwg.org/#special-scheme), and the two forms parse very
-differently:
+[special scheme](https://url.spec.whatwg.org/#special-scheme), and the two forms (with and
+without the `//`) parse very differently:
 
 - `ipfs://{cid}/{path}` has `//`, so the parser reads `{cid}` as the authority and `{path}` as a
   segmented, relative-resolvable path. The result is a URL that can be a base for relative

--- a/src/ipfs-uri.md
+++ b/src/ipfs-uri.md
@@ -1,0 +1,329 @@
+---
+title: IPFS URI (ipfs://)
+description: >
+  The ipfs:// URI scheme for addressing immutable, content-addressed data by
+  CID, defined for interoperability with web browsers.
+date: 2026-08-02
+maturity: draft
+editors:
+  - name: Marcin Rataj
+    github: lidel
+    affiliation:
+      name: Interplanetary Shipyard
+      url: https://ipshipyard.com/
+thanks:
+  - name: Jonny Crunch
+    github: jonnycrunch
+  - name: Dietrich Ayala
+    github: autonome
+  - name: Frédéric Wang
+    github: fred-wang
+    affiliation:
+      name: Igalia
+      url: https://igalia.com/
+  - name: bumblefudge
+    github: bumblefudge
+tags: ['routing']
+order: 4
+---
+
+The `ipfs://` URI scheme names **immutable** content by its CID (:cite[cid]).
+An `ipfs://` URI is a native address that a browser-like application can open directly,
+without hard-coding an HTTP gateway. It is one half of native IPFS addressing;
+the mutable half is the [`ipns://`](https://specs.ipfs.tech/ipns-uri/) scheme.
+
+## What is it?
+
+An `ipfs://` URI places a content root in the URI **authority** and an optional path after it:
+
+```text
+ipfs://{cid}/{path}?{query}#{fragment}
+```
+
+For example:
+
+```text
+ipfs://bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq/wiki/Vincent_van_Gogh.html#some-fragment
+ipfs://bafybeietjm63oynimmv5yyqay33nui4y4wx6u3peezwetxgiwvfmelutzu/subdir/hello.txt?filename=index.html
+```
+
+The authority (`{cid}`) is a self-describing content address. Because a CID is derived from
+the bytes it names, the data behind an `ipfs://` URI can never change: the same URI always
+resolves to the same content, and any resolver can verify it received exactly those bytes.
+
+For this reason, an `ipfs://` URI MUST address only immutable, content-addressed data.
+A pointer whose target its owner can update later (a cryptographic IPNS name or a DNSLink
+name) is mutable and MUST NOT be placed under `ipfs://`; it belongs under
+[`ipns://`](https://specs.ipfs.tech/ipns-uri/) instead.
+
+## Syntax
+
+An `ipfs://` URI always uses the **authority form**: the `//` is required. The ABNF below
+describes it; rules named but not defined here (`pct-encoded`, `segment`, `query`, `fragment`)
+come from :cite[rfc3986].
+
+```abnf
+ipfs-URI       = "ipfs://" ipfs-authority path-abempty
+                 [ "?" query ] [ "#" fragment ]
+
+ipfs-authority = cidv1-base32       ; canonical authority form; see "What the authority
+                                    ; may contain" for other case-insensitive encodings
+
+cidv1-base32   = "b" 1*base32char   ; multibase 'b': RFC4648 base32, lowercase, no padding
+                                    ; MUST decode to a valid CIDv1
+base32char     = %x32-37 / %x61-7A  ; "2"-"7" / "a"-"z"
+
+path-abempty   = *( "/" segment )   ; RFC 3986, Section 3.3
+```
+
+The ABNF describes the **canonical** form only: an authority that is a `base32` CIDv1. A URI
+whose authority uses another case-insensitive multibase does not match this grammar but can
+still appear as input; [What the authority may contain](#what-the-authority-may-contain) says
+how to handle it: normalize to `base32`, or reject.
+
+An `ipfs://` URI is a URL as defined by the
+[WHATWG URL Standard](https://url.spec.whatwg.org/). The ABNF above is descriptive; when it and
+the WHATWG parser disagree, **the WHATWG parser wins**, because this scheme exists to behave
+well in browsers. This tie-breaker applies throughout this document.
+
+## Authority
+
+In the [WHATWG URL Standard](https://url.spec.whatwg.org/), the component after `//` is the
+URL's authority. An `ipfs://` URI is read the same way: its authority is the content root, a
+single CID. Reading `ipfs://{cid}/{path}` as a URL is what lets
+the CID define an [Origin](#origin) and anchor a relative path.
+
+The `//` is required. Neither `ipfs` nor `ipns` is a
+[special scheme](https://url.spec.whatwg.org/#special-scheme), so without `//` there is no
+authority, and without an authority there is nothing to attach a stable origin to. The opaque
+`ipfs:{cid}` form has neither; producers MUST NOT emit it.
+[Reading `ipfs://` as a WHATWG URL](#reading-ipfs-as-a-whatwg-url) shows how the two forms parse.
+
+### What the authority may contain
+
+- The authority is a single content root and nothing else: userinfo and port MUST NOT appear.
+  A CID identifies content no matter where or how it is retrieved, so a gateway host or any
+  other endpoint information does not belong in the URI. There is no `ipfs://host:port/{cid}`
+  form.
+- The content root MUST decode to a valid CIDv1.
+- It MUST be encoded in a **case-insensitive** multibase, so it survives being
+  parsed into the authority (see
+  [Why the authority must be case-insensitive](#why-the-authority-must-be-case-insensitive)).
+- It SHOULD be encoded as **`base32`** (multibase prefix `b`). base32 is the canonical form:
+  the string browsers and other agents use as the [origin](#origin) when they sandbox the
+  content. Implementations MUST accept `base32`, and producers SHOULD emit it.
+- Another case-insensitive multibase (for example `base36`, prefix `k`) MAY appear in the
+  authority, but it is a different string and therefore a different origin. An implementation
+  encountering one MUST either normalize it to `base32` before computing any origin or issuing
+  any request, or reject the URI; resolving the non-canonical form in place would split one
+  content root into several origins.
+- The content root SHOULD NOT exceed **63 characters**. The limit is DNS-specific: a single DNS
+  label caps at 63 characters, and staying within it is what lets the root serve as a
+  Subdomain Gateway (:cite[subdomain-gateway]) label and its
+  origin. A local resolver or a native `ipfs://` implementation is not bound by DNS and MAY
+  support a longer root, for example by mapping it to a localhost subdomain that public DNS
+  never sees. Such roots cripple interoperability, though, and SHOULD be kept to internal use.
+  An implementation that cannot rely on such a mapping SHOULD reject a root longer than 63
+  characters.
+- The content root MUST NOT contain any code point that the WHATWG URL Standard lists as a
+  [forbidden host code point](https://url.spec.whatwg.org/#forbidden-host-code-point) or
+  [forbidden domain code point](https://url.spec.whatwg.org/#forbidden-domain-code-point)
+  (notably `%`).
+- A producer MUST NOT emit a case-sensitive encoding: a **CIDv0** (`base58btc` `Qm...`) or a
+  `base58btc` CIDv1 (`z...`) is corrupted once the authority is case-folded (see
+  [Why the authority must be case-insensitive](#why-the-authority-must-be-case-insensitive)).
+- A consumer that receives such an authority with its case still intact, such as a `base64url`
+  CIDv1 (`u...`) or a CIDv0 (`Qm...`), SHOULD normalize it rather than reject it: decode the CID
+  and re-encode it as canonical `base32` before rendering the URI, computing an origin, or issuing
+  a request. Every recoverable case decodes to the same CID, so normalizing loses nothing.
+
+An authority that neither satisfies these rules nor can be normalized to canonical `base32` under
+them MUST be rejected as unresolvable. Implementations SHOULD show an error explaining why the
+address cannot work instead of forwarding the URI to a resolver or gateway that can only fail.
+
+### Origin
+
+The content root defines the security context of the content it names, mirroring the Subdomain
+Gateway origin model: `ipfs://{cid}/{path}` and `https://{cid}.ipfs.example.net/{path}` name the
+same content under the same origin model, where the CID is the origin-defining label.
+
+On its own, the WHATWG URL Standard gives every non-special URL, `ipfs://` included, a
+[new opaque origin](https://url.spec.whatwg.org/#concept-url-origin) on each parse. That alone
+does not give the property this scheme needs: same CID, same origin; different CID, different
+origin. To get it, an implementation SHOULD derive the origin from the scheme and the content root
+alone, so that the content root is the only thing the origin depends on.
+
+How that origin is serialized is left to the implementation, because it depends on what the host
+environment can be made to express. Two forms are known to work:
+
+- `ipfs://{cid}` as a tuple origin in its own right. This is the form to prefer, and the only one
+  available to an implementation with a native `ipfs://` handler.
+- `http://{cid}.ipfs.localhost:{port}` where a native scheme is not possible, for example when the
+  content is served through a gateway on loopback. `*.localhost` names resolve locally rather than
+  through public DNS, and browsers treat them as a secure context without a TLS certificate, so
+  each content root still lands in its own origin.
+
+Either way the origin is keyed on the authority string, which browsers and other agents use to
+sandbox JavaScript storage (`localStorage`, IndexedDB, Cache Storage) and to scope API permissions.
+Two encodings of the same CID are two different strings, and therefore two different origins with
+separate storage and permissions. Normalizing the authority to canonical `base32` keeps each
+content root in a single security context under either serialization.
+
+## Path, query, and fragment
+
+- **Path.** `ipfs://{cid}/{path}` maps to the content path `/ipfs/{cid}/{path}` by
+  concatenation of the authority and the path segments. The URI path MUST NOT repeat the `/ipfs/`
+  namespace prefix, which the scheme already implies; a path segment that happens to be named
+  `ipfs` further down the DAG is ordinary content and is left alone. An empty path and a path of
+  `/` both address the content root itself. The path is passed as-is: this specification adds no
+  encoding or decoding beyond what the WHATWG URL parser already does. What the segments mean is
+  decided by the content root, as described below.
+- **Query.** A query, if present, is carried through to the resolver unchanged, with no
+  encoding or decoding beyond what the WHATWG URL parser already does.
+- **Fragment.** A fragment is a client-side component of the URL and is passed through: when the
+  URI is mapped to a gateway URL, the fragment is carried onto that URL unchanged. It MUST NOT be
+  sent in retrieval requests, and it plays no part in resolution.
+
+### How the content root drives traversal
+
+A CID is self-describing, and its multicodec is what tells a resolver both how to decode the block
+the CID addresses and how to walk `{path}` out of that block. Nothing in the URI selects this
+behavior, and nothing needs to: the codec in the content root does.
+
+- `dag-pb` is read as UnixFS (:cite[unixfs]), so path segments are directory and file names.
+- `dag-cbor` holds structured data, and a path segment names a field within it. A field whose value
+  is a CID carried under
+  [CBOR tag 42](https://datatracker.ietf.org/doc/draft-caballero-cbor-cbor42/) is a link, and
+  following it moves the traversal into a different document.
+- `raw` is opaque bytes with no links to follow, so a non-empty path has nowhere to go.
+
+This applies at every step, not only the first. Each link the traversal follows carries its own CID
+with its own codec, so the rules can change partway down a path: a `dag-cbor` root can link to a
+`dag-pb` node, after which the remaining segments are UnixFS names. Path Gateway
+(:cite[path-gateway]) defines the traversal itself, including how an unresolvable path is reported.
+
+## Resolution
+
+To resolve an `ipfs://` URI, an implementation builds the content path
+`/ipfs/{cid}/{path}` and retrieves it through any IPFS retrieval mechanism: for example, a
+Path Gateway request to `https://example.net/ipfs/{cid}/{path}`, or a Subdomain Gateway request to
+`https://{cid}.ipfs.example.net/{path}` when an isolated origin is needed. The query is
+carried through; the fragment stays client-side.
+
+A resolver that retrieves blocks itself, over a Trustless Gateway (:cite[trustless-gateway]) or a
+peer-to-peer transport, MUST verify them: hash every block it receives and walk the DAG from the
+content root, so that each block on the path is accounted for. Verification is what lets an
+`ipfs://` URI be trusted regardless of where the bytes came from.
+
+Retrieval through a trusted Path or Subdomain Gateway is the exception: the gateway performs that
+verification and the client takes its word for it. An implementation that resolves `ipfs://` this
+way SHOULD make the gateway it trusts visible to the user, because the immutability guarantee then
+rests on that gateway rather than on the URI.
+
+A native `ipfs://` implementation SHOULD resolve content paths with the same semantics as a
+Path Gateway, so that the same URI resolves consistently whether it is opened by a native handler
+or handed to a gateway. In a browser-like context, a native implementation SHOULD also mirror the
+origin isolation that a Subdomain Gateway provides, giving each content root its own origin (see
+[Origin](#origin)).
+
+## Notes for implementers
+
+This section is non-normative: it explains the reasoning behind the rules above and adds no
+new requirements.
+
+### Reading `ipfs://` as a WHATWG URL
+
+The `//` is what makes the content root an authority. Neither `ipfs` nor `ipns` is a
+[special scheme](https://url.spec.whatwg.org/#special-scheme), and the two forms parse very
+differently:
+
+- `ipfs://{cid}/{path}` has `//`, so the parser reads `{cid}` as the authority and `{path}` as a
+  segmented, relative-resolvable path. The result is a URL that can be a base for relative
+  references: a document at `ipfs://{cid}/a/` that links to `b` resolves cleanly to
+  `ipfs://{cid}/a/b`.
+- `ipfs:{cid}` has no `//`, so the parser reads the whole remainder as an
+  [opaque path](https://url.spec.whatwg.org/#url-opaque-path): there is no authority, the path is
+  a single opaque string that is not segmented, and the URL cannot be a base for relative
+  references.
+
+Only a form with an authority can be given a stable origin, which is why the authority form is
+required and the opaque `ipfs:{cid}` form is not used to address content.
+
+### Why the authority must be case-insensitive
+
+A CIDv0 is `base58btc`, whose alphabet is case-sensitive and contains uppercase letters. An
+authority is not a safe place for it, for two independent reasons:
+
+1. Any engine that treats `ipfs` as a
+   [special scheme](https://url.spec.whatwg.org/#special-scheme) parses the authority as a domain
+   via [domain to ASCII](https://url.spec.whatwg.org/#concept-domain-to-ascii), which case-folds
+   ASCII uppercase to lowercase. A lowercased `base58btc` string is a different, invalid CID.
+   Percent-encoding cannot rescue it, because `%` is itself a forbidden domain code point.
+2. Even when they do not, deployed browsers and other user agents force-lowercase URL
+   authorities before any resolver sees them.
+
+`base32` avoids both: its alphabet is all-lowercase and contains no forbidden code point, so it
+survives every parse unchanged. The same case-folding applies to a Subdomain Gateway label
+(`{cid}.ipfs.example.net`), which additionally caps the root at 63 characters (the DNS label
+limit), so only a case-insensitive CIDv1 that fits a label can serve as both an authority and a
+stable origin on the public web. This is why case-insensitivity is a correctness and security
+property, not a stylistic preference.
+
+CIDv0 stays safe in any position that is not an authority, such as a path segment.
+
+### Normalizing the authority
+
+The rules in [What the authority may contain](#what-the-authority-may-contain) describe two
+normalization paths that end in the same place, canonical `base32`, for two different reasons:
+
+- A **case-sensitive** encoding (a CIDv0 `Qm...`, or a CIDv1 in `base58btc` or `base64url`)
+  cannot be relied on to survive parsing: engines and user agents case-fold authorities, and a
+  folded string no longer decodes. Catching such input while its case is intact and converting
+  it (decode, then re-encode as a `base32` CIDv1) rescues it losslessly.
+- A **case-insensitive** but non-canonical encoding (for example `base36`) survives parsing
+  fine, but it is a different authority string and would become a different origin. Normalizing
+  it is canonicalization rather than rescue: one content root keeps one origin and one storage
+  sandbox.
+
+In both cases, normalize (or redirect to the normalized URI) before computing an origin or
+issuing a request.
+
+### Roots longer than 63 characters
+
+A CIDv1 with a large multihash, `sha2-512` being the common case, produces a `base32` string
+longer than 63 characters. Such a root cannot become a DNS label, so Subdomain Gateway deployments
+that rely on public DNS and wildcard TLS certificates cannot serve it and respond with HTTP 400;
+representing such CIDs there remains an
+[open question](https://github.com/ipfs/kubo/issues/7318).
+
+The limit is specific to those PKI/TLS deployments. A localhost subdomain gateway
+(`{cid}.ipfs.localhost`) or a native `ipfs://` implementation is not bound by it: `*.localhost`
+subdomains are resolved locally rather than through public DNS, and browsers treat them as a
+secure context without TLS certificates. Per
+[What the authority may contain](#what-the-authority-may-contain), long roots are best kept to
+internal use; on the public web, `sha2-256` remains the safe default.
+
+## IANA considerations
+
+`ipfs` is registered as a provisional URI scheme under the procedure of :cite[rfc7595]:
+[IANA provisional registration for `ipfs`](https://www.iana.org/assignments/uri-schemes/prov/ipfs).
+That registration is the authoritative record of the scheme name, status, applications, and
+change controller; this document does not repeat them.
+
+This specification supplies what the provisional registration leaves open:
+
+- **Scheme syntax:** the authority form in [Syntax](#syntax).
+- **Encoding considerations:** the content root is canonically a `base32` CIDv1 (see
+  [what the authority may contain](#what-the-authority-may-contain)); path, query, and fragment
+  follow the WHATWG URL Standard, as described in
+  [Path, query, and fragment](#path-query-and-fragment).
+- **Interoperability considerations:** `ipfs` is a non-special scheme in the WHATWG URL
+  Standard. The required authority form and the case-insensitive `base32` CIDv1 authority (see
+  [what the authority may contain](#what-the-authority-may-contain) and [Origin](#origin)) exist
+  so the URI parses consistently across engines and can define a stable origin.
+- **Security considerations:** the security context derives from the content root (see
+  [Origin](#origin)), retrieved bytes are verified against the CID (see
+  [Resolution](#resolution)), and the authority's case-insensitivity is a security property.
+  Case-folding a case-sensitive root corrupts the CID itself: the multihash digest can no longer
+  be decoded, nothing can be verified against it, and two distinct security contexts could also
+  collide into one. Only case-insensitive bases such as `base32` are safe in URIs.

--- a/src/ipns-uri.md
+++ b/src/ipns-uri.md
@@ -220,11 +220,11 @@ This section is non-normative.
 ### Why base36 for Ed25519
 
 A single DNS label is capped at 63 characters, and an authority that should double as a
-subdomain-gateway label inherits that cap. An Ed25519
-`libp2p-key` CIDv1 is about 40 bytes; its `base32` string runs to roughly 64 characters, just
-over the limit, while its `base36` string (`k51...`) fits. base32 remains fine for shorter
-identifiers, but base36 is what keeps an Ed25519 IPNS name usable as an authority and as a
-Subdomain Gateway label.
+subdomain-gateway label inherits that cap. Because an Ed25519 key is inlined rather than hashed
+(see [Keys too big to inline](#keys-too-big-to-inline)), its `libp2p-key` CIDv1 is 40 bytes, the
+largest an IPNS name gets in practice. That is 65 characters in `base32`, two over the limit, and
+63 in `base36` (`k51...`), which just fits. base32 remains fine for the shorter, hashed names, but
+base36 is what keeps an Ed25519 IPNS name usable as an authority and as a Subdomain Gateway label.
 
 ### Room for new key types
 
@@ -237,8 +237,8 @@ key container codecs that drop the libp2p wrapper altogether. Both directions ar
 The codec rule in [Cryptographic key form](#cryptographic-key-form) is written to survive that: it
 names no fixed set and leaves each implementation to say which codecs it accepts. What does not
 change is the shape of the authority, a case-insensitive CIDv1 that fits a DNS label. Post-quantum
-public keys are considerably larger than Ed25519 ones, so a key that does not fit runs into the
-same wall as an RSA name (see [RSA names may not fit](#rsa-names-may-not-fit)).
+public keys are far too large to inline, so their names will be digests rather than keys, with the
+consequences described in [Keys too big to inline](#keys-too-big-to-inline).
 
 ### Keep the whole resolution chain
 
@@ -250,14 +250,27 @@ answers a different question later: the DNS name is the human-readable origin, t
 :ref[IPNS Name] fetches the latest content from the same publisher even if the domain lapses,
 and the CID retrieves the exact saved version for as long as anyone keeps it available.
 
-### RSA names may not fit
+### Keys too big to inline
 
-An RSA key produces a `libp2p-key` CIDv1 large enough to exceed 63 characters, so an RSA IPNS
-name cannot become a subdomain label on gateway deployments that rely on public DNS and wildcard
-TLS certificates (see the
-[`ipfs://` note on long roots](https://specs.ipfs.tech/ipfs-uri/#roots-longer-than-63-characters)).
-A local resolver or a `*.localhost` gateway can still serve it. Prefer Ed25519 for public
-interoperability.
+An :ref[IPNS Name] is a multihash of the serialized public key, so how big that key is decides
+what the name actually carries.
+
+- A small key is hashed with `identity`, which stores the key verbatim inside the multihash. The
+  name *is* the key, and a resolver can recover it by decoding the authority. Ed25519 is the case
+  that matters: its serialized form is 36 bytes, inside the 42-byte inlining threshold.
+- A larger key, RSA or ECDSA today, is hashed with `sha2-256` instead. The name commits to the key
+  without carrying it, so the authority is a 32-byte digest no matter how big the key was.
+
+The second case produces the *shorter* name, not the longer one: about 57 characters in base36
+against 63 for an inlined Ed25519 key. The 63-character DNS label limit is a constraint on inlined
+keys, and it does not bite here.
+
+What does bite is that the key cannot be recovered from the name, so a resolver has to obtain it
+some other way before it can check a signature. Records for such keys carry a serialized copy of
+the public key alongside the signature, and a resolver MUST confirm that the copy hashes back to
+the authority before trusting it (:cite[ipns-record]). Because the authority is exactly the hash of
+those key bytes, the key is itself content-addressed: it can be stored and fetched as immutable
+data under the same multihash rather than travelling in every record.
 
 ## IANA considerations
 

--- a/src/ipns-uri.md
+++ b/src/ipns-uri.md
@@ -1,0 +1,274 @@
+---
+title: IPNS URI (ipns://)
+description: >
+  The ipns:// URI scheme for addressing mutable pointers, cryptographic IPNS
+  names and DNSLink names, defined for interoperability with web browsers.
+date: 2026-08-02
+maturity: draft
+editors:
+  - name: Marcin Rataj
+    github: lidel
+    affiliation:
+      name: Interplanetary Shipyard
+      url: https://ipshipyard.com/
+thanks:
+  - name: Frédéric Wang
+    github: fred-wang
+    affiliation:
+      name: Igalia
+      url: https://igalia.com/
+  - name: Jonny Crunch
+    github: jonnycrunch
+  - name: Dietrich Ayala
+    github: autonome
+  - name: bumblefudge
+    github: bumblefudge
+xref:
+  - ipns-record
+tags: ['ipns']
+order: 2
+---
+
+The `ipns://` URI scheme names **mutable** pointers. It is the mutable sibling of the
+[`ipfs://`](https://specs.ipfs.tech/ipfs-uri/) scheme, and shares its structure, syntax, origin
+model, and its deferral of path, query, and fragment handling to the WHATWG URL parser. This
+document defines only what is specific to `ipns://`: what its content root may contain, and how
+that root is resolved.
+
+Read [`ipfs://`](https://specs.ipfs.tech/ipfs-uri/) first: it defines everything the two
+schemes share, including the authority form and why `//` is required, the origin model, path,
+query, and fragment behavior, the ban on endpoint information, and the shape of the IANA
+registration. This document does not repeat it.
+
+## What is it?
+
+An `ipns://` URI places a mutable content root in the authority and an optional path after it:
+
+```text
+ipns://{ipns-name}/{path}?{query}#{fragment}
+```
+
+For example:
+
+```text
+ipns://k51qzi5uqu5dlvj2baxnqndepeb86cbk3ng7n3i46uzyxzyqj2xjonzllnv0v8/
+ipns://dnslink.example.net/wiki/
+```
+
+`ipns://{ipns-name}/{path}` maps to the content path `/ipns/{ipns-name}/{path}`.
+
+Because the target of an IPNS name can be republished to point at different content over time,
+an `ipns://` URI is a **mutable** pointer. `ipns://` MUST NOT be used as a namespace for a bare
+CID that directly names immutable bytes: such a CID belongs under
+[`ipfs://`](https://specs.ipfs.tech/ipfs-uri/). The only CIDs valid under `ipns://` are those that
+name a public key, `libp2p-key` CIDv1s today: a key is a mutable pointer to content, where a bare
+content CID is not (see [The content root](#the-content-root)).
+
+## The content root
+
+`ipns://` supports two kinds of content root, and every implementation MUST accept both:
+
+- an :ref[IPNS Name], a cryptographic key defined in :cite[ipns-record], and
+- a DNS name resolved via DNSLink.
+
+They are told apart by trying the first and falling back to the second: an implementation attempts
+to parse the authority as a CIDv1, and only if that fails does it treat the authority as a DNSLink
+domain. [Parsing the authority](#parsing-the-authority) gives the exact steps.
+
+```abnf
+ipns-URI       = "ipns://" ipns-authority path-abempty
+                 [ "?" query ] [ "#" fragment ]
+
+ipns-authority = ipns-key / dnslink-name
+
+; (a) IPNS Name: a CIDv1 naming a public key, multibase base36
+;     (libp2p-key, 0x72, is the codec in use today)
+ipns-key       = "k" 1*base36char   ; canonical form; see "Cryptographic key form"
+                                    ; for other case-insensitive encodings
+                                    ; a single DNS label, no "."
+                                    ; SHOULD NOT exceed 63 characters total
+base36char     = %x30-39 / %x61-7A  ; "0"-"9" / "a"-"z"
+
+; (b) DNSLink name: an ICANN-compatible DNS name, at least one "." on the public internet
+dnslink-name   = label 1*( "." label )
+label          = let-dig [ *61( let-dig / "-" ) let-dig ]  ; RFC 1123: max 63 characters,
+                                                           ; no leading or trailing "-"
+let-dig        = %x61-7A / %x30-39                         ; lowercase; DNS comparison
+                                                           ; is case-insensitive
+```
+
+As in [`ipfs://`](https://specs.ipfs.tech/ipfs-uri/#syntax), the ABNF describes the **canonical**
+form only: a `base36` key. A key in another case-insensitive multibase does not match `ipns-key`
+but can still appear as input;
+[Cryptographic key form](#cryptographic-key-form) says how to handle it.
+
+`path-abempty`, `query`, and `fragment` are as in [`ipfs://`](https://specs.ipfs.tech/ipfs-uri/#syntax).
+The same WHATWG-URL-governs tie-breaker applies.
+
+### Cryptographic key form
+
+- When the content root is a cryptographic key, it MUST be an :ref[IPNS Name]: a CIDv1
+  (:cite[cid]) that names a public key, as defined by :cite[ipns-record].
+- The key MUST be encoded in a case-insensitive multibase and SHOULD use **base36** (multibase
+  prefix `k`). base36 is to `ipns://` what `base32` is to
+  [`ipfs://`](https://specs.ipfs.tech/ipfs-uri/#origin): the canonical
+  [origin](https://specs.ipfs.tech/ipfs-uri/#origin) string, so producers SHOULD normalize to it
+  and keep one key in one sandbox for storage and permissions. Wherever the authority also has to
+  work as a DNS label, an Ed25519 key MUST use base36: its `base32` encoding exceeds the
+  63-character limit below (see [Why base36 for Ed25519](#why-base36-for-ed25519)).
+- The authority SHOULD NOT exceed **63 characters**: the DNS label limit that lets an IPNS name
+  serve as a Subdomain Gateway (:cite[subdomain-gateway]) label and its origin. As with
+  [`ipfs://`](https://specs.ipfs.tech/ipfs-uri/#what-the-authority-may-contain), a local resolver
+  or native implementation MAY support a longer name for internal use, for example via a
+  localhost subdomain; an implementation that cannot SHOULD reject it.
+- A case-sensitive `base58btc` identifier, whether a CIDv0 (`Qm...`) or a legacy peer-id string
+  (`12D3Koo...`), MUST NOT appear in the authority, for the same reason it is unsafe in an
+  [`ipfs://`](https://specs.ipfs.tech/ipfs-uri/#why-the-authority-must-be-case-insensitive)
+  authority: it is lowercased and destroyed when parsed into the authority.
+- The CID's multicodec says how the public key is wrapped. This specification does not fix the set
+  of acceptable codecs: an implementation decides which key types and which key container codecs,
+  `libp2p-key` (`0x72`) among them, it accepts, so a new key type can be deployed without revising
+  this document (see [Room for new key types](#room-for-new-key-types)). An implementation SHOULD
+  document the set it supports, and SHOULD support `libp2p-key`, the only codec in wide use today.
+- An implementation given a codec it does not support MUST NOT resolve the name as though the codec
+  were one it does. It either rejects the authority, per
+  [Parsing the authority](#parsing-the-authority), or normalizes it to a codec it does support and
+  redirects to the corrected URI. Falling back to `libp2p-key` over the same multihash is a
+  reasonable last resort when nothing else matches.
+
+### DNSLink name form
+
+- When the content root is a DNS name, it MUST be resolved via DNSLink
+  (:cite[dnslink-gateway]), and for the public internet it MUST be an ICANN-compatible DNS name:
+  lowercase LDH labels (letters, digits, hyphens, with no leading or trailing hyphen) joined by at
+  least one `.`. The dot both reflects public DNS structure and keeps the DNS name distinct from a
+  single-label cryptographic key.
+- An internationalized name MUST be converted to its ASCII form (`xn--...` punycode labels) via
+  [domain to ASCII](https://url.spec.whatwg.org/#concept-domain-to-ascii) before it is placed in
+  the authority; the authority itself carries only LDH labels.
+- DNSLink resolution MUST enforce a hard recursion limit (for example 32) and fail when it is
+  exceeded, as required by :cite[dnslink-gateway].
+
+### Parsing the authority
+
+The key form is tried first and the DNSLink form is the fallback. The order is what makes the two
+unambiguous in the one place they could collide, a dot-less authority: a canonical `ipns-key` is a
+single label with no dot, and a public DNSLink name always has at least one. A resolver MUST apply
+these steps in order.
+
+1. **Try the key form.** Parse the authority as a CIDv1. If it decodes to a CID that satisfies
+   [Cryptographic key form](#cryptographic-key-form), it is an :ref[IPNS Name]: resolve it as a key
+   and stop. If it decodes to a CID whose codec the implementation does not support, reject or
+   redirect per that section, and stop.
+2. **Fall back to DNSLink.** If the CIDv1 parse failed and the authority contains a `.`, treat it
+   as a DNSLink name and resolve it per [DNSLink name form](#dnslink-name-form), then stop.
+3. **Try the inlined label.** Otherwise the authority is a single label that is not a key. A
+   resolver SHOULD decode it with the Subdomain Gateway's DNSLink label encoding and retry step 2
+   with the result, which is what lets an inlined label round-trip back into a dotted name (see
+   [Resolution](#resolution)).
+4. **Otherwise reject** the authority as unresolvable, as in
+   [`ipfs://`](https://specs.ipfs.tech/ipfs-uri/#what-the-authority-may-contain). Implementations
+   SHOULD present an error explaining why, rather than forwarding the name to a resolver that can
+   only fail.
+
+A DNSLink name is never mistaken for a key, because a dotted name cannot decode as a CIDv1 and a
+key never contains a dot. Trying the key form first also means a name that would decode as a CID is
+always read as a key, which is what keeps one identifier from resolving two different ways in two
+different implementations.
+
+Step 3 is also where a local-resolver extension for dot-less names would sit. Such names are out of
+scope for public-internet `ipns://` URIs, because they are network-relative: the same origin string
+can name different content on different networks. Origin-scoped state (storage, permissions)
+sandboxed under such a name can therefore leak between unrelated sites, so an implementation
+offering the extension SHOULD account for the instability, for example by not persisting that
+state.
+
+## Resolution
+
+Resolution has one step that `ipfs://` does not. The content root is mutable, so it MUST first be
+resolved to an immutable CID: an :ref[IPNS Name] through its signed record, a DNSLink name through
+DNS, which may itself point at another DNSLink name or at an :ref[IPNS Name] before it bottoms out.
+Everything after that is identical to `ipfs://`. The CID that comes out is the content root for the
+rest of the operation, and its multicodec is what says how to decode the root block and how to walk
+`{path}` out of it, exactly as in
+[`ipfs://`](https://specs.ipfs.tech/ipfs-uri/#how-the-content-root-drives-traversal). Only the step
+that produces the CID differs; the traversal does not.
+
+Otherwise resolution follows [`ipfs://`](https://specs.ipfs.tech/ipfs-uri/#resolution), with the
+IPNS namespace in place of the IPFS one: `ipns://{ipns-name}/{path}` is retrieved as the content
+path `/ipns/{ipns-name}/{path}`, for example through a Subdomain Gateway request to
+`https://{ipns-name}.ipns.example.net/{path}` when an isolated origin is required.
+
+A DNSLink name cannot appear in a subdomain as-is: its dots would create extra DNS levels and
+break wildcard TLS, so the Subdomain Gateway inlines the name into a single label, turning
+`ipns://dnslink.example.net` into `https://dnslink-example-net.ipns.example.net`. Each `.` becomes
+a `-`, and any `-` already in the name is doubled, so `ipns://my-site.example.net` inlines to
+`my--site-example-net`.
+Step 3 of [Parsing the authority](#parsing-the-authority) is what lets that inlined label come back
+the other way. The canonical `ipns://` URI always uses the original dotted name, never the inlined
+label, so an implementation SHOULD normalize an inlined label back to its dotted form before
+rendering the URI or deriving its origin.
+
+When the content root is a cryptographic key, a resolver MUST validate the IPNS record's
+signature as defined by :cite[ipns-record]. When it is a DNS name, DNSLink resolution applies,
+including its recursion bound (see [DNSLink name form](#dnslink-name-form)).
+
+## Notes for implementers
+
+This section is non-normative.
+
+### Why base36 for Ed25519
+
+A single DNS label is capped at 63 characters, and an authority that should double as a
+subdomain-gateway label inherits that cap. An Ed25519
+`libp2p-key` CIDv1 is about 40 bytes; its `base32` string runs to roughly 64 characters, just
+over the limit, while its `base36` string (`k51...`) fits. base32 remains fine for shorter
+identifiers, but base36 is what keeps an Ed25519 IPNS name usable as an authority and as a
+Subdomain Gateway label.
+
+### Room for new key types
+
+In practice an IPNS name today is a `libp2p-key` (`0x72`), which wraps the public key in a libp2p
+protobuf. Post-quantum signature schemes are expected to change that, either as new key types
+carried inside that same wrapper, which leaves the authority untouched, or under self-describing
+key container codecs that drop the libp2p wrapper altogether. Both directions are tracked in
+[ipfs/kubo#11281](https://github.com/ipfs/kubo/issues/11281).
+
+The codec rule in [Cryptographic key form](#cryptographic-key-form) is written to survive that: it
+names no fixed set and leaves each implementation to say which codecs it accepts. What does not
+change is the shape of the authority, a case-insensitive CIDv1 that fits a DNS label. Post-quantum
+public keys are considerably larger than Ed25519 ones, so a key that does not fit runs into the
+same wall as an RSA name (see [RSA names may not fit](#rsa-names-may-not-fit)).
+
+### Keep the whole resolution chain
+
+An `ipns://` address resolves through layers: a DNSLink name points at an :ref[IPNS Name] or
+directly at a CID, and an :ref[IPNS Name] resolves to a CID. An application that saves an
+address, as a bookmark or before pinning, benefits from recording every layer it resolved
+through: the DNS name, the :ref[IPNS Name] behind it, and the CID at save time. Each layer
+answers a different question later: the DNS name is the human-readable origin, the
+:ref[IPNS Name] fetches the latest content from the same publisher even if the domain lapses,
+and the CID retrieves the exact saved version for as long as anyone keeps it available.
+
+### RSA names may not fit
+
+An RSA key produces a `libp2p-key` CIDv1 large enough to exceed 63 characters, so an RSA IPNS
+name cannot become a subdomain label on gateway deployments that rely on public DNS and wildcard
+TLS certificates (see the
+[`ipfs://` note on long roots](https://specs.ipfs.tech/ipfs-uri/#roots-longer-than-63-characters)).
+A local resolver or a `*.localhost` gateway can still serve it. Prefer Ed25519 for public
+interoperability.
+
+## IANA considerations
+
+`ipns` is registered as a provisional URI scheme under the procedure of :cite[rfc7595]:
+[IANA provisional registration for `ipns`](https://www.iana.org/assignments/uri-schemes/prov/ipns).
+That registration is the authoritative record of the scheme name, status, applications, and
+change controller; this document does not repeat them. The considerations are as for
+[`ipfs://`](https://specs.ipfs.tech/ipfs-uri/#iana-considerations), with these additions:
+
+- **Scheme syntax:** the authority forms in [The content root](#the-content-root).
+- **Security considerations:** resolving an `ipns://` URI dereferences a mutable pointer, so the
+  content it names can change between retrievals. Record signature validation and the DNSLink
+  recursion bound are defined in [Resolution](#resolution) and
+  [DNSLink name form](#dnslink-name-form).

--- a/src/ipns-uri.md
+++ b/src/ipns-uri.md
@@ -3,7 +3,7 @@ title: IPNS URI (ipns://)
 description: >
   The ipns:// URI scheme for addressing mutable pointers, cryptographic IPNS
   names and DNSLink names, defined for interoperability with web browsers.
-date: 2026-08-02
+date: 2026-08-03
 maturity: draft
 editors:
   - name: Marcin Rataj
@@ -140,9 +140,9 @@ The same WHATWG-URL-governs tie-breaker applies.
 
 - When the content root is a DNS name, it MUST be resolved via DNSLink
   (:cite[dnslink-gateway]), and for the public internet it MUST be an ICANN-compatible DNS name:
-  lowercase LDH labels (letters, digits, hyphens, with no leading or trailing hyphen) joined by at
-  least one `.`. The dot both reflects public DNS structure and keeps the DNS name distinct from a
-  single-label cryptographic key.
+  lowercase LDH labels (ASCII letters, digits, hyphens, with no leading or trailing hyphen) joined
+  by at least one dot (`.`). The dot both reflects public DNS structure and keeps the DNS name
+  distinct from a single-label cryptographic key.
 - An internationalized name MUST be converted to its ASCII form (`xn--...` punycode labels) via
   [domain to ASCII](https://url.spec.whatwg.org/#concept-domain-to-ascii) before it is placed in
   the authority; the authority itself carries only LDH labels.

--- a/src/ipns-uri.md
+++ b/src/ipns-uri.md
@@ -4,7 +4,7 @@ description: >
   The ipns:// URI scheme for addressing mutable pointers, cryptographic IPNS
   names and DNSLink names, defined for interoperability with web browsers.
 date: 2026-08-03
-maturity: draft
+maturity: reliable
 editors:
   - name: Marcin Rataj
     github: lidel


### PR DESCRIPTION
## Problem

What browsers and gateways need to know about `ipfs://` and `ipns://` has only ever lived in [ADDRESSING.md](https://github.com/ipfs/in-web-browsers/blob/9b58085129b55fc70c1f417fe69b989a22af1e43/ADDRESSING.md), a memo in `ipfs/in-web-browsers`. Nothing can cite a memo, and it leaves the sharp edges implicit: why the authority has to survive case-folding, what actually defines an origin, when a CID must be normalized before a request goes out. Implementers keep rediscovering those by shipping something that breaks.

## Fix

Two draft specs that supersede the memo:

- `ipfs-uri.md`: the required authority form, base32 normalization of the content root, the origin model and the two serializations that work, and how the root CID's codec decides path traversal.
- `ipns-uri.md`: the IPNS Name and DNSLink authority forms, the ordered parse that separates them, and a key codec rule left open so post-quantum keys can land without a revision.

They also fill in the syntax, encoding, interoperability, and security sections that the IANA provisional registrations for [`ipfs`](https://www.iana.org/assignments/uri-schemes/prov/ipfs) and [`ipns`](https://www.iana.org/assignments/uri-schemes/prov/ipns) left open. Gateway behavior is unchanged, and path resolution stays in the Path Gateway spec.

## Refs

- Closes #138
- Closes #248
- Closes #432
- Closes #474