### PR TITLE
docs: require CAR fixtures for CIDs in specs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,151 @@
+# Working on ipfs/specs
+
+Guidance for anyone editing this repository, human or agent.
+
+## Every CID and content path needs retrievable data
+
+A specification that names a CID is making a promise: a reader can fetch it and
+see what the text describes. That promise decays. Pinning services lapse, test
+nodes get reinstalled, and a CID that resolved when the PR merged returns
+nothing two years later. The reader is then stuck with a hash and no way to
+check the spec against reality.
+
+So: **a pull request that adds or changes a CID, or a content path such as
+`/ipfs/<cid>/dir/file.html`, must attach a `.zip` containing CAR files that
+cover it.** Attach the zip to the PR description, then link it from the spec
+text as an HTTPS URL so readers can reach the data without the PR.
+
+`.car` is not an allowed GitHub attachment type, so archive the CARs in a
+`.zip`. The limit is 25 MB per attachment.
+
+### How much data to include
+
+Match the coverage to what the text asks of the reader.
+
+| the spec says | ship |
+| --- | --- |
+| fetch this and verify your implementation against it | the complete DAG |
+| this path resolves to that content | the blocks along that path |
+| here is an example CID or URL | the root block, so the CID is provably real |
+
+Partial CARs are acceptable and often preferred. A 1 GiB fixture whose point is
+"the root has 1024 links" is fully served by a 51 KB CAR holding the root and
+internal nodes. A directory listing example does not need the file contents.
+See [Partial CARs](#partial-cars) below.
+
+Two kinds of CID are exempt:
+
+- Identity CIDs (`bafkqa…`), where the data is inside the CID string.
+- CIDs that are deliberately unresolvable, such as blocked-content examples in
+  a denylist spec. Label these in the text so a reader does not waste time
+  trying to fetch them.
+
+### Prefer an existing upstream CAR
+
+Before generating a new fixture, check whether one already exists at a tagged
+path in [ipfs/gateway-conformance][gwc], [ipld/codec-fixtures][cf], or
+[ipfs/boxo][boxo]. Most fixtures in this repository already do. A link to a
+tagged file in a real repository is more durable than an attachment, it is in
+git, and CI can verify it. Link that instead of attaching a copy.
+
+[gwc]: https://github.com/ipfs/gateway-conformance
+[cf]: https://github.com/ipld/codec-fixtures
+[boxo]: https://github.com/ipfs/boxo
+
+## Producing CARs
+
+### Full DAG
+
+    ipfs dag export <cid> > fixture.car
+
+### Partial CARs
+
+For the blocks needed to resolve one path, ask your own kubo gateway for a
+scoped CAR. `dag-scope=block` returns the path blocks plus the terminating
+block. `dag-scope=entity` also returns the whole file or directory at the end
+of the path.
+
+    curl -o path.car \
+      "http://127.0.0.1:8080/ipfs/<cid>/<path>?format=car&dag-scope=block"
+
+Use your own node, not a public gateway. It fetches what it needs, you keep the
+blocks locally, and the recipe does not depend on someone else's server staying
+online.
+
+To export whatever a local node happens to hold, skipping missing subtrees:
+
+    ipfs dag export --local-only <cid> > partial.car   # kubo 0.43+
+
+### Importing a partial CAR into kubo
+
+A partial CAR holds an incomplete DAG on purpose, so root pinning cannot
+succeed. Turn it off:
+
+    ipfs dag import --pin-roots=false partial.car
+
+On kubo 0.43 and later, `--local-only` does the same and states the intent:
+
+    ipfs dag import --local-only partial.car
+
+Plain `ipfs dag import` fails on a partial CAR with `pinning root ... FAILED`,
+because the default pins each root and pinning walks the whole DAG. The blocks
+are still imported when this happens.
+
+### Verifying before you attach
+
+Import into a scratch repository and confirm the CAR delivers what the spec
+claims.
+
+    export IPFS_PATH=$(mktemp -d)
+    ipfs init --profile=test
+    ipfs dag import --pin-roots=false fixture.car
+    ipfs dag stat --offline <cid>          # full DAG: must succeed
+    ipfs cat --offline /ipfs/<cid>/<path>  # partial: the documented path must resolve
+
+## Every zip needs a README
+
+A CAR file on its own tells a reader nothing about why it exists. Include a
+`README.md` in the zip covering:
+
+- one row per CAR: filename, CID, whether it is a full or partial DAG, and what
+  it lets the reader verify
+- for partial CARs, which paths or structural claims they cover, and what is
+  deliberately absent
+- what the payload is, in plain terms. "Pseudo-random bytes from a ChaCha20
+  keystream" saves a reader from running `file` on it and guessing.
+- how to regenerate the data, if it is generated rather than authored. Give the
+  seed, the algorithm, and a runnable command.
+- the import commands from above, including the `--pin-roots=false` note if any
+  CAR is partial
+
+[`ipip-0499-test-fixtures.zip`][example-zip] is a worked example of this
+layout. It carries full CARs for the fixtures that fit, structure-only CARs for
+the five oversized ones, a Go module that regenerates those five and checks
+them against the published CIDs, and a README tying each file back to a row of
+the [IPIP-0499](src/ipips/ipip-0499.md) fixture table.
+
+[example-zip]: https://github.com/user-attachments/files/31088958/ipip-0499-test-fixtures.zip
+
+## When data is too large to attach
+
+Some DAGs run to gigabytes. Options, in order of preference:
+
+1. Ship a partial CAR that covers the structural claim or the path in the text.
+2. Ship code that regenerates the fixture, with the seed and parameters, plus a
+   script that verifies the output CID matches. Keep it in the zip next to the
+   CARs.
+3. Say plainly in the spec that the CID is a large historical snapshot and only
+   part of it is preserved.
+
+Never leave a large CID in the text with nothing behind it.
+
+## Keeping fixtures alive
+
+Attaching a CAR protects the data. It does not keep the CID resolvable on the
+IPFS network, which is what a reader will try first. Pin new fixtures somewhere
+durable and give the pin a name that ties it back to the document, for example
+`ipip-499_test-fixtures`.
+
+When a fixture's definition changes, the CID changes. Re-pin the new CID and
+update the attachment in the same PR. A stale pin under the right name is
+indistinguishable from a healthy one until someone tries to fetch it.

--- a/ipip-template.md
+++ b/ipip-template.md
@@ -67,6 +67,11 @@ specification compliance. This section can be skipped if IPIP does not deal
 with the way IPFS handles content-addressed data, or the modified specification
 file already includes this information.
 
+Every CID listed here needs CAR coverage attached to the pull request and
+linked from this section, so a reader can still fetch the data years later.
+See [AGENTS.md](AGENTS.md) for how much to attach, when a partial CAR is
+enough, and how to import one.
+
 ### Copyright
 
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/src/http-gateways/web-redirects-file.md
+++ b/src/http-gateways/web-redirects-file.md
@@ -174,6 +174,7 @@ The [max file size](#max-file-size) helps to prevent an additional [denial of se
 
 Sample files for various test cases can be found in `QmQyqMY5vUBSbSxyitJqthgwZunCQjDVtNd8ggVCxzuPQ4`.
 Implementations SHOULD use it for internal testing.
+The data is available as [`redirects.car`](https://github.com/ipfs/gateway-conformance/raw/refs/tags/v0.13.2/fixtures/redirects_file/redirects.car).
 
 ```
 $ ipfs ls QmQyqMY5vUBSbSxyitJqthgwZunCQjDVtNd8ggVCxzuPQ4
@@ -219,6 +220,7 @@ $ ipfs cat /ipfs/QmYBhLYDwVFvxos9h8CGU2ibaY66QNgv8hpfewxaQrPiZj/_redirects
 
 A dedicated test vector with URL query parameter behavior can be found in `bafybeiee3ltldvmfgsxiqazbatrkbvkl34eanbourajwnavhupb64nnbxa`.
 Implementations SHOULD use it for internal testing when [query parameter support](#query-parameters) is desired.
+The data is available as [`redirects-query-params.car`](https://github.com/ipfs/boxo/raw/refs/tags/v0.42.1/gateway/testdata/redirects-query-params.car).
 
 ```
 $ ipfs cat bafybeiee3ltldvmfgsxiqazbatrkbvkl34eanbourajwnavhupb64nnbxa/_redirects

--- a/src/ipips/ipip-0002.md
+++ b/src/ipips/ipip-0002.md
@@ -54,7 +54,8 @@ The detailed specification is added in :cite[web-redirects-file].
 
 ### Test fixtures
 
-`QmQyqMY5vUBSbSxyitJqthgwZunCQjDVtNd8ggVCxzuPQ4`
+`QmQyqMY5vUBSbSxyitJqthgwZunCQjDVtNd8ggVCxzuPQ4`, available as
+[`redirects.car`](https://github.com/ipfs/gateway-conformance/raw/refs/tags/v0.13.2/fixtures/redirects_file/redirects.car).
 
 See spec for testing details.
 

--- a/src/ipips/ipip-0288.md
+++ b/src/ipips/ipip-0288.md
@@ -71,7 +71,8 @@ that should be handled. To test such behaviors, the following fixtures can be us
 - [`bafkreict7qp5aqs52445bk4o7iuymf3davw67tpqqiscglujx3w6r7hwoq`][inside-dag-tar]
   is an example TAR file that corresponds to the aforementioned UnixFS DAG. Its
   structure can be inspected in order to check if new implementations conform
-  to the specification.
+  to the specification. It ships as `cars/ipip-0288_tar-export.car` inside the
+  linked archive.
 
 - [`bafybeicaj7kvxpcv4neaqzwhrqqmdstu4dhrwfpknrgebq6nzcecfucvyu`][outside-dag]
   is a UnixFS DAG that contains a file with a name that looks like a relative
@@ -151,6 +152,6 @@ but decided against it as gzip or alternative compression may be introduced on t
 
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
 
-[inside-dag]: https://dweb.link/ipfs/bafybeibfevfxlvxp5vxobr5oapczpf7resxnleb7tkqmdorc4gl5cdva3y?format=car
-[inside-dag-tar]: https://dweb.link/ipfs/bafkreict7qp5aqs52445bk4o7iuymf3davw67tpqqiscglujx3w6r7hwoq?format=car
-[outside-dag]: https://dweb.link/ipfs/bafybeicaj7kvxpcv4neaqzwhrqqmdstu4dhrwfpknrgebq6nzcecfucvyu?format=car
+[inside-dag]: https://github.com/ipfs/gateway-conformance/raw/refs/tags/v0.13.2/fixtures/path_gateway_tar/inside-root.car
+[inside-dag-tar]: https://github.com/user-attachments/files/31090406/ipfs-specs-fixtures.zip
+[outside-dag]: https://github.com/ipfs/gateway-conformance/raw/refs/tags/v0.13.2/fixtures/path_gateway_tar/outside-root.car

--- a/src/ipips/ipip-0328.md
+++ b/src/ipips/ipip-0328.md
@@ -177,8 +177,8 @@ Copyright and related rights waived via [CC0](https://creativecommons.org/public
 [DAG-CBOR]: https://ipld.io/docs/codecs/known/dag-cbor/
 [CAR]: https://ipld.io/specs/transport/car/
 [ipfs/go-ipfs/issues/7552]: https://github.com/ipfs/go-ipfs/issues/7552
-[f-dag-pb]: https://dweb.link/ipfs/bafybeiegxwlgmoh2cny7qlolykdf7aq7g6dlommarldrbm7c4hbckhfcke
-[f-dag-pb-json]: https://dweb.link/ipfs/bafkreidmwhhm6myajxlpu7kofe3aqwf4ezxxn46cp5fko7mb6x74g4k5nm
+[f-dag-pb]: https://github.com/ipfs/gateway-conformance/raw/refs/tags/v0.13.2/fixtures/path_gateway_dag/dag-pb.car
+[f-dag-pb-json]: https://github.com/ipfs/gateway-conformance/raw/refs/tags/v0.13.2/fixtures/path_gateway_dag/dag-pb.json
 [rfc8259-sec12]: https://datatracker.ietf.org/doc/html/rfc8259#section-12
 [rfc8949-sec10]: https://datatracker.ietf.org/doc/html/rfc8949#section-10
 [dag-json-spec]: https://ipld.io/specs/codecs/dag-json/spec/

--- a/src/ipips/ipip-0386.md
+++ b/src/ipips/ipip-0386.md
@@ -82,7 +82,9 @@ not found in the directory identified by the CID or DNSLink name.
 ## Test fixtures
 
 The example from the :cite[web-redirects-file] can be re-used,
-`QmYBhLYDwVFvxos9h8CGU2ibaY66QNgv8hpfewxaQrPiZj`.
+`QmYBhLYDwVFvxos9h8CGU2ibaY66QNgv8hpfewxaQrPiZj`. It is the `examples/`
+directory inside
+[`redirects.car`](https://github.com/ipfs/gateway-conformance/raw/refs/tags/v0.13.2/fixtures/redirects_file/redirects.car).
 
 ```
 $ ipfs ls /ipfs/QmYBhLYDwVFvxos9h8CGU2ibaY66QNgv8hpfewxaQrPiZj

--- a/src/ipips/ipip-0428.md
+++ b/src/ipips/ipip-0428.md
@@ -165,6 +165,11 @@ years, making them safe for use in CI tests.
 5. [V1+V2](https://dweb.link/ipfs/bafybeifkipmlz2fehxda6y7x752uolfed7bdd46jzdammpfga5zrnkq33u/k51qzi5uqu5dilgf7gorsh9vcqqq4myo6jd4zmqkuy9pxyxi5fua3uf7axph4y_v1-v2-broken-signature-v1.ipns-record) (only signatureV2 valid) → record valid, value points at `/ipfs/bafkqahtwgevxmmrao5uxi2bamjzg623fnyqhg2lhnzqxi5lsmuqhmmi`
 6. [V2-only](https://dweb.link/ipfs/bafybeifkipmlz2fehxda6y7x752uolfed7bdd46jzdammpfga5zrnkq33u/k51qzi5uqu5dit2ku9mutlfgwyz8u730on38kd10m97m36bjt66my99hb6103f_v2.ipns-record) (no V1 fields) → record valid
 
+The records are checked into gateway-conformance under
+[`fixtures/ipns_records/`](https://github.com/ipfs/gateway-conformance/tree/refs/tags/v0.13.2/fixtures/ipns_records),
+and the directory above ships as `cars/ipip-0428_ipns-records.car` inside
+[`ipfs-specs-fixtures.zip`](https://github.com/user-attachments/files/31090406/ipfs-specs-fixtures.zip).
+
 :::note
 
 Implementers can either write own tests against the above test vectors, or run

--- a/src/ipns/ipns-record.md
+++ b/src/ipns/ipns-record.md
@@ -450,6 +450,11 @@ years, making them safe for use in CI tests.
 5. [V1+V2](https://dweb.link/ipfs/bafybeifkipmlz2fehxda6y7x752uolfed7bdd46jzdammpfga5zrnkq33u/k51qzi5uqu5dilgf7gorsh9vcqqq4myo6jd4zmqkuy9pxyxi5fua3uf7axph4y_v1-v2-broken-signature-v1.ipns-record) (only signatureV2 valid) → record valid, value points at `/ipfs/bafkqahtwgevxmmrao5uxi2bamjzg623fnyqhg2lhnzqxi5lsmuqhmmi`
 6. [V2-only](https://dweb.link/ipfs/bafybeifkipmlz2fehxda6y7x752uolfed7bdd46jzdammpfga5zrnkq33u/k51qzi5uqu5dit2ku9mutlfgwyz8u730on38kd10m97m36bjt66my99hb6103f_v2.ipns-record) (no V1 fields) → record valid
 
+The records are checked into gateway-conformance under
+[`fixtures/ipns_records/`](https://github.com/ipfs/gateway-conformance/tree/refs/tags/v0.13.2/fixtures/ipns_records),
+and the directory above ships as `cars/ipip-0428_ipns-records.car` inside
+[`ipfs-specs-fixtures.zip`](https://github.com/user-attachments/files/31090406/ipfs-specs-fixtures.zip).
+
 :::note
 
 Implementers can either write own tests against the above test vectors, or run

--- a/src/unixfs.md
+++ b/src/unixfs.md
@@ -740,7 +740,9 @@ Test vectors for UnixFS file structures, progressing from simple single-block fi
 
 ### Single `dag-pb` Block File
 
-- Fixture: Well-known test CID from IPFS Gateway Checker
+- Fixture: Well-known test CID from IPFS Gateway Checker, shipped as
+  `cars/unixfs_gateway-checker-file.car` inside
+  [`ipfs-specs-fixtures.zip`](https://github.com/user-attachments/files/31090406/ipfs-specs-fixtures.zip)
 - CID: `bafybeifx7yeb55armcsxwwitkymga5xf53dxiarykms3ygqic223w5sk3m`
 - Type: [`dag-pb` File](#dag-pb-file) with data in the same block
 - Content: "Hello from IPFS Gateway Checker\n" (32 bytes)


### PR DESCRIPTION
A CID in a spec promises a reader can fetch it and check the text against reality. Nothing enforces that today. #499 showed the cost: the file-over-max-links vector was redefined, the new CID was never pinned, and the spec pointed at unretrievable data until a reader reported it.

- CIDs and content paths added by a PR need CAR coverage attached, scaled to what the text asks of the reader
- partial CARs are acceptable; a 1 GiB fixture whose claim is structural ships as a 51 KB CAR of root and the minimal set of  internal nodes referenced from spec
- prefer an existing tagged CAR in gateway-conformance, codec-fixtures or boxo over attaching a copy
- identity CIDs and deliberately unresolvable CIDs are exempt
- each zip carries a README covering what every CAR verifies
- documents partial CAR import, where kubo's default pin-roots fails on an incomplete DAG

Backfilled existing specs  + added missing ones in:
- [ipfs-specs-fixtures.zip](https://github.com/user-attachments/files/31090406/ipfs-specs-fixtures.zip)
